### PR TITLE
tests/testDRP.py: replace Popen with call to check the return value

### DIFF
--- a/python/pfs/drp/stella/reduceArcRefSpecTask.py
+++ b/python/pfs/drp/stella/reduceArcRefSpecTask.py
@@ -43,7 +43,7 @@ class ReduceArcRefSpecTaskRunner(TaskRunner):
             try:
                 result = task.run(**args)
             except Exception, e:
-                task.log.fatal("Failed: %s" % e)
+                task.log.warn("Failed: %s" % e)
 
         if self.doReturnResults:
             return Struct(

--- a/python/pfs/drp/stella/reduceArcTask.py
+++ b/python/pfs/drp/stella/reduceArcTask.py
@@ -38,8 +38,7 @@ class ReduceArcTaskRunner(TaskRunner):
             try:
                 result = task.run(**args)
             except Exception, e:
-                task.log.fatal("Failed: %s" % e)
-#                traceback.print_exc(file=sys.stderr)
+                task.log.warn("Failed: %s" % e)
 
         if self.doReturnResults:
             return Struct(

--- a/tests/testDRP.py
+++ b/tests/testDRP.py
@@ -32,39 +32,46 @@ class testDRPTestCase(tests.TestCase):
 
     def testDRP(self):
         logLevel = {0: "WARN", 1: "INFO", 2: "DEBUG"}[verbose]
-        subprocess.Popen(["bin/reduceArcRefSpec.py",
-                          self.testDataDir,
-                          "--id",
-                          "visit=%d" % (self.arcVisit,),
-                          "--refSpec",
-                          "%s" % (self.refSpec),
-                          "--lineList", "%s" % (self.lineList),
-                          "--loglevel",
-                          "%s" % (logLevel),
-                          "--calib",
-                          "%s" % (self.testCalibDir),
-                          "--output",
-                          "%s" % (self.testDataDir),
-                          "--clobber-config",
-                          "--clobber-versions"
-                         ] )
-        subprocess.Popen(["bin/reduceArc.py",
-                          self.testDataDir,
-                          "--id",
-                          "visit=%d" % (self.arcVisit),
-                          "--wLenFile",
-                          "%s" % (self.wLenFile),
-                          "--lineList",
-                          "%s" % (self.lineList),
-                          "--loglevel",
-                          "%s" % (logLevel),
-                          "--calib",
-                          "%s" % (self.testCalibDir),
-                          "--output",
-                          "%s" % (self.testDataDir),
-                          "--clobber-config",
-                          "--clobber-versions"
-                         ])
+        proc = subprocess.Popen(["bin/reduceArcRefSpec.py",
+                                 self.testDataDir,
+                                 "--id",
+                                 "visit=%d" % (self.arcVisit,),
+                                 "--refSpec",
+                                 "%s" % (self.refSpec),
+                                 "--lineList", "%s" % (self.lineList),
+                                 "--loglevel",
+                                 "%s" % (logLevel),
+                                 "--calib",
+                                 "%s" % (self.testCalibDir),
+                                 "--output",
+                                 "%s" % (self.testDataDir),
+                                 "--clobber-config",
+                                 "--clobber-versions",
+                                 "--doraise"
+                                ])
+        proc.communicate()
+        self.assertEqual(proc.returncode, 0)
+
+        proc = subprocess.Popen(["bin/reduceArc.py",
+                                 self.testDataDir,
+                                 "--id",
+                                 "visit=%d" % (self.arcVisit),
+                                 "--wLenFile",
+                                 "%s" % (self.wLenFile),
+                                 "--lineList",
+                                 "%s" % (self.lineList),
+                                 "--loglevel",
+                                 "%s" % (logLevel),
+                                 "--calib",
+                                 "%s" % (self.testCalibDir),
+                                 "--output",
+                                 "%s" % (self.testDataDir),
+                                 "--clobber-config",
+                                 "--clobber-versions",
+                                 "--doraise"
+                                ])
+        proc.communicate()
+        self.assertEqual(proc.returncode, 0)
 
 #-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 


### PR DESCRIPTION
"subprocess.Popen" simply starts the command in the background while
the rest of the script is continued. In contrast to that,
"subprocess.call" waits for the command to complete and returns the
"returncode" attribute which we need to check to see if our test
was successful.