### PR TITLE
Use . not :: as a separator in loggers

### DIFF
--- a/examples/overplotFiberTraceCenter.py
+++ b/examples/overplotFiberTraceCenter.py
@@ -14,12 +14,12 @@ for logger in ["afw.ExposureFormatter",
                "CameraMapper",
                "daf.persistence.LogicalLocation",
                "daf.persistence.butler",
-               "pfs::drp::stella::FiberTrace::calcProfile",
-               "pfs::drp::stella::FiberTrace::calcProfileSwath",
-               "pfs::drp::stella::FiberTrace::extractFromProfile",
-               "pfs::drp::stella::math::CurveFitting::LinFitBevingtonNdArray1D",
-               "pfs::drp::stella::math::CurveFitting::LinFitBevingtonNdArray2D",
-               "pfs::drp::stella::math::CurfFitting::PolyFit",
+               "pfs.drp.stella.FiberTrace.calcProfile",
+               "pfs.drp.stella.FiberTrace.calcProfileSwath",
+               "pfs.drp.stella.FiberTrace.extractFromProfile",
+               "pfs.drp.stella.math.CurveFitting.LinFitBevingtonNdArray1D",
+               "pfs.drp.stella.math.CurveFitting.LinFitBevingtonNdArray2D",
+               "pfs.drp.stella.math.CurveFittingPolyFit",
               ]:
     log.Log.getLogger(logger).setLevel(log.WARN)
 

--- a/src/FiberTraces.cc
+++ b/src/FiberTraces.cc
@@ -1350,7 +1350,7 @@ namespace pfs { namespace drp { namespace stella {
   template<typename ImageT, typename MaskT, typename VarianceT>
   PTR( SpectrumSet<ImageT, MaskT, VarianceT, VarianceT> ) FiberTraceSet<ImageT, MaskT, VarianceT>::extractAllTracesFromProfile()
   {
-    LOG_LOGGER _log = LOG_GET("pfs::drp::stella::FiberTraceSet::extractAllTracesFromProfile");
+    LOG_LOGGER _log = LOG_GET("pfs.drp.stella.FiberTraceSet.extractAllTracesFromProfile");
     PTR( SpectrumSet<ImageT, MaskT, VarianceT, VarianceT> ) spectrumSet ( new SpectrumSet<ImageT, MaskT, VarianceT, VarianceT>( _traces->size() ) );
     for (size_t i = 0; i < _traces->size(); ++i){
       LOGLS_DEBUG(_log, "extracting FiberTrace " << i);
@@ -2314,7 +2314,7 @@ namespace pfs { namespace drp { namespace stella {
     void assignITrace( FiberTraceSet< ImageT, MaskT, VarianceT > & fiberTraceSet,
                        ndarray::Array< T, 1, I > const& fiberIds,
                        ndarray::Array< U, 1, I > const& xCenters ){
-      LOG_LOGGER _log = LOG_GET("pfs::drp::stella::math::assignITrace");
+      LOG_LOGGER _log = LOG_GET("pfs.drp.stella.math.assignITrace");
 
       size_t iTrace;
       size_t startPos = 0;
@@ -2348,7 +2348,7 @@ namespace pfs { namespace drp { namespace stella {
                        size_t nTraces,
                        size_t nRows,
                        size_t startPos ){
-      LOG_LOGGER _log = LOG_GET("pfs::drp::stella::math::findITrace");
+      LOG_LOGGER _log = LOG_GET("pfs.drp.stella.math.findITrace");
       float xCenter = fiberTrace.getFiberTraceFunction()->xCenter;
       unsigned int yCenter = fiberTrace.getFiberTraceFunction()->yCenter;
       LOGLS_DEBUG(_log, "xCenter = " << xCenter);
@@ -2431,7 +2431,7 @@ namespace pfs { namespace drp { namespace stella {
         dataXY<CoordT> const& ccdCoordinates,
         pfs::drp::stella::FiberTrace<ImageT, MaskT, VarianceT> const& fiberTrace)
     {
-      LOG_LOGGER _log = LOG_GET("pfs::drp::stella::math::ccdToFiberTraceCoordinates");
+      LOG_LOGGER _log = LOG_GET("pfs.drp.stella.math.ccdToFiberTraceCoordinates");
       dataXY<CoordT> coordsOut;
 
       ndarray::Array< size_t, 2, 1 > minCenMax = calcMinCenMax(
@@ -2461,7 +2461,7 @@ namespace pfs { namespace drp { namespace stella {
         dataXY<CoordT> const& ccdCoordinatesCenter,
         pfs::drp::stella::FiberTrace<ImageT, MaskT, VarianceT> const& fiberTrace)
     {
-      LOG_LOGGER _log = LOG_GET("pfs::drp::stella::math::fiberTraceCoordinatesRelativeTo");
+      LOG_LOGGER _log = LOG_GET("pfs.drp.stella.math.fiberTraceCoordinatesRelativeTo");
 
       dataXY<CoordT> traceCoordinatesCenter = ccdToFiberTraceCoordinates(
               ccdCoordinatesCenter,

--- a/src/Spectra.cc
+++ b/src/Spectra.cc
@@ -509,7 +509,7 @@ template< typename T >
 ndarray::Array<float, 1, 1 >
 Spectrum<ImageT, MaskT, VarianceT, WavelengthT>::hIdentify( ndarray::Array< T, 2, 1 > const& lineList )
 {
-  LOG_LOGGER _log = LOG_GET("Spectra::identify");
+  LOG_LOGGER _log = LOG_GET("pfs.drp.stella.Spectra.identify");
   ///for each line in line list, find maximum in spectrum and fit Gaussian
   int I_MaxPos = 0;
   int I_Start = 0;
@@ -679,7 +679,7 @@ void
 Spectrum<ImageT, MaskT, VarianceT, WavelengthT>::identify( ndarray::Array< T, 2, 1 > const& lineList,
                                                                                      DispCorControl const& dispCorControl,
                                                                                      std::size_t nLinesCheck ){
-    LOG_LOGGER _log = LOG_GET("Spectra::identify");
+    LOG_LOGGER _log = LOG_GET("pfs.drp.stella.Spectra.identify");
 
     DispCorControl tempDispCorControl( dispCorControl );
     _dispCorControl.reset();
@@ -1275,39 +1275,39 @@ namespace math {
       ndarray::Array< size_t, 1, 1 > ind = math::getIndicesInValueRange( wLen, T( 1 ), T( 15000 ) );
       assert(ind.getShape()[0] > 0);
       #ifdef __DEBUG_CREATELINELIST__
-        cout << "Spectra::createLineList: ind = " << ind.getShape() << ": " << ind << endl;
+        cout << "pfs.drp.stella.Spectra.createLineList: ind = " << ind.getShape() << ": " << ind << endl;
       #endif
       ndarray::Array< T, 1, 1 > indT = ndarray::allocate( ind.getShape()[ 0 ] );
       indT.deep() = ind;
       #ifdef __DEBUG_CREATELINELIST__
-        cout << "Spectra::createLineList: indT = " << indT.getShape() << ": " << indT << endl;
-        cout << "Spectra::createLineList: ind[0] = " << ind[0] << ", ind[ind.getShape()[0](=" << ind.getShape()[0] << ")-1] = " << ind[ind.getShape()[0]-1] << endl;
+        cout << "pfs.drp.stella.Spectra.createLineList: indT = " << indT.getShape() << ": " << indT << endl;
+        cout << "pfs.drp.stella.Spectra.createLineList: ind[0] = " << ind[0] << ", ind[ind.getShape()[0](=" << ind.getShape()[0] << ")-1] = " << ind[ind.getShape()[0]-1] << endl;
       #endif
       ndarray::Array< T, 1, 1 > wavelengths = ndarray::copy( wLen[ ndarray::view( ind[ 0 ], ind[ ind.getShape()[ 0 ] - 1 ] + 1 ) ] );
       #ifdef __DEBUG_CREATELINELIST__
         for (int i = 0; i < indT.getShape()[ 0 ]; ++i )
-          cout << "Spectra::createLineList: indT[" << i << "] = " << indT[ i ] << ": wavelengths[" << i << "] = " << wavelengths[ i ] << endl;
+          cout << "pfs.drp.stella.Spectra.createLineList: indT[" << i << "] = " << indT[ i ] << ": wavelengths[" << i << "] = " << wavelengths[ i ] << endl;
       #endif
       std::vector< std::string > args( 1 );
       #ifdef __DEBUG_CREATELINELIST__
-        cout << "Spectra::createLineList: intT = " << indT.getShape() << ": " << indT << endl;
-        cout << "Spectra::createLineList: wavelengths = " << wavelengths.getShape() << ": " << wavelengths << endl;
-        cout << "Spectra::createLineList: linesWLen = " << linesWLen.getShape() << ": " << linesWLen << endl;
-        cout << "Spectra::createLineList: args = " << args.size() << endl;
+        cout << "pfs.drp.stella.Spectra.createLineList: intT = " << indT.getShape() << ": " << indT << endl;
+        cout << "pfs.drp.stella.Spectra.createLineList: wavelengths = " << wavelengths.getShape() << ": " << wavelengths << endl;
+        cout << "pfs.drp.stella.Spectra.createLineList: linesWLen = " << linesWLen.getShape() << ": " << linesWLen << endl;
+        cout << "pfs.drp.stella.Spectra.createLineList: args = " << args.size() << endl;
       #endif
       ndarray::Array< T, 1, 1 > linesPix = math::interPol( indT, wavelengths, linesWLen, args );
       #ifdef __DEBUG_CREATELINELIST__
-        cout << "Spectra::createLineList: linesWLen = " << linesWLen.getShape() << ": " << linesWLen << endl;
+        cout << "pfs.drp.stella.Spectra.createLineList: linesWLen = " << linesWLen.getShape() << ": " << linesWLen << endl;
       #endif
       ndarray::Array< T, 2, 1 > out = ndarray::allocate( linesWLen.getShape()[ 0 ], 2 );
       #ifdef __DEBUG_CREATELINELIST__
-        cout << "Spectra::createLineList: out = " << out.getShape() << endl;
-        cout << "Spectra::createLineList: out[ ndarray::view( )( 0 ) ].getShape() = " << out[ ndarray::view( )( 0 ) ].getShape() << endl;
+        cout << "pfs.drp.stella.Spectra.createLineList: out = " << out.getShape() << endl;
+        cout << "pfs.drp.stella.Spectra.createLineList: out[ ndarray::view( )( 0 ) ].getShape() = " << out[ ndarray::view( )( 0 ) ].getShape() << endl;
       #endif
       out[ ndarray::view( )( 0 ) ] = linesWLen;//[ ndarray::view( ) ];
       out[ ndarray::view( )( 1 ) ] = linesPix;//[ ndarray::view( ) ];
       #ifdef __DEBUG_CREATELINELIST__
-        cout << "Spectra::createLineList: out = " << out << endl;
+        cout << "pfs.drp.stella.Spectra.createLineList: out = " << out << endl;
       #endif
       return out;
     }

--- a/src/math/CurveFitting.cc
+++ b/src/math/CurveFitting.cc
@@ -102,11 +102,11 @@ namespace pfs { namespace drp { namespace stella { namespace math {
                                        size_t const I_NIter,
                                        std::vector<std::string> const& S_A1_Args_In,
                                        std::vector<void *> &ArgV){
-    LOG_LOGGER _log = LOG_GET("pfs::drp::stella::math::CurfFitting::PolyFit");
+    LOG_LOGGER _log = LOG_GET("pfs.drp.stella.math.CurveFitting.PolyFit");
 
-    LOGLS_DEBUG(_log, "CurveFitting::PolyFit(x, y, deg, lReject, uReject, nIter, Args, ArgV) started");
+    LOGLS_DEBUG(_log, "PolyFit(x, y, deg, lReject, uReject, nIter, Args, ArgV) started");
     if (D_A1_X_In.getShape()[0] != D_A1_Y_In.getShape()[0]){
-      std::string message("pfs::drp::stella::math::CurfFitting::PolyFit: ERROR: D_A1_X_In.getShape()[0](=");
+      std::string message("pfs::drp::stella::math::CurveFitting::PolyFit: ERROR: D_A1_X_In.getShape()[0](=");
       message += std::to_string(D_A1_X_In.getShape()[0]) + " != D_A1_Y_In.getShape()[0](=" + std::to_string(D_A1_Y_In.getShape()[0]) + ")";
       throw LSST_EXCEPT(pexExcept::Exception, message.c_str());
     }
@@ -310,7 +310,7 @@ namespace pfs { namespace drp { namespace stella { namespace math {
     }
     LOGLS_DEBUG(_log, "*P_I_NRejected = " << *P_I_NRejected);
     *P_I_A1_NotRejected = I_A1_OrigPos;
-    LOGLS_DEBUG(_log, "CurveFitting::PolyFit(x, y, deg, lReject, uReject, nIter, Args, ArgV) finished");
+    LOGLS_DEBUG(_log, "PolyFit(x, y, deg, lReject, uReject, nIter, Args, ArgV) finished");
     return D_A1_Coeffs_Out;
   }
 
@@ -322,8 +322,8 @@ namespace pfs { namespace drp { namespace stella { namespace math {
                                        size_t const I_Degree_In,
                                        T xRangeMin_In,
                                        T xRangeMax_In){
-    LOG_LOGGER _log = LOG_GET("pfs::drp::stella::math::CurfFitting::PolyFit");
-    LOGLS_DEBUG(_log, "CurveFitting::PolyFit(x, y, deg, xRangeMin, xRangeMax) started");
+    LOG_LOGGER _log = LOG_GET("pfs.drp.stella.math.CurveFitting.PolyFit");
+    LOGLS_DEBUG(_log, "PolyFit(x, y, deg, xRangeMin, xRangeMax) started");
     if (D_A1_X_In.getShape()[0] != D_A1_Y_In.getShape()[0]){
       std::string message("pfs::drp::stella::math::CurveFitting::PolyFit: ERROR: D_A1_X_In.getShape()[0](=");
       message += std::to_string(D_A1_X_In.getShape()[0]) +") != D_A1_Y_In.getShape()[0](=" + std::to_string(D_A1_Y_In.getShape()[0]) + ")";
@@ -351,7 +351,7 @@ namespace pfs { namespace drp { namespace stella { namespace math {
                                        size_t const I_Degree_In,
                                        std::vector<std::string> const& S_A1_Args_In,
                                        std::vector<void *> & ArgV){
-    LOG_LOGGER _log = LOG_GET("pfs::drp::stella::math::CurfFitting::PolyFit");
+    LOG_LOGGER _log = LOG_GET("pfs.drp.stella.math.CurveFitting.PolyFit");
     LOGLS_DEBUG(_log, "PolyFit(x, y, deg, Args, ArgV) started");
     if (D_A1_X_In.getShape()[0] != D_A1_Y_In.getShape()[0]){
       std::string message("pfs::drp::stella::math::CurveFitting::PolyFit: ERROR: D_A1_X_In.getShape()[0](=");
@@ -576,7 +576,7 @@ namespace pfs { namespace drp { namespace stella { namespace math {
                                        size_t const I_NIter,
                                        T xRangeMin_In,
                                        T xRangeMax_In){
-    LOG_LOGGER _log = LOG_GET("pfs::drp::stella::math::CurfFitting::PolyFit");
+    LOG_LOGGER _log = LOG_GET("pfs.drp.stella.math.CurveFitting.PolyFit");
     LOGLS_DEBUG(_log, "PolyFit(x, y, deg, lReject, hReject, nIter, xRangeMin, xRangeMax) started");
     std::vector<std::string> S_A1_Args(1);
     S_A1_Args[0] = "XRANGE";

--- a/tests/FiberTraces.py
+++ b/tests/FiberTraces.py
@@ -869,12 +869,12 @@ def run(exit = False):
     for logger in ["afw.image.ExposureInfo",
                    "afw.image.Mask",
                    "CameraMapper",
-                   "pfs::drp::stella::FiberTrace::calcProfile",
-                   "pfs::drp::stella::FiberTrace::calcProfileSwath",
-                   "pfs::drp::stella::FiberTrace::extractFromProfile",
-                   "pfs::drp::stella::math::CurveFitting::LinFitBevingtonNdArray1D",
-                   "pfs::drp::stella::math::CurveFitting::LinFitBevingtonNdArray2D",
-                   "pfs::drp::stella::math::CurfFitting::PolyFit",
+                   "pfs.drp.stella.FiberTrace.calcProfile",
+                   "pfs.drp.stella.FiberTrace.calcProfileSwath",
+                   "pfs.drp.stella.FiberTrace.extractFromProfile",
+                   "pfs.drp.stella.math.CurveFitting.LinFitBevingtonNdArray1D",
+                   "pfs.drp.stella.math.CurveFitting.LinFitBevingtonNdArray2D",
+                   "pfs.drp.stella.math.CurveFitting.PolyFit",
                    ]:
         log.Log.getLogger(logger).setLevel(log.WARN)
 

--- a/tests/Spectra.py
+++ b/tests/Spectra.py
@@ -594,7 +594,7 @@ class SpectraTestCase(tests.TestCase):
                 self.dispCorControl.maxDistance = maxDistance
                 if maxDistance < 0.49:
                     try:
-                        logger = log.Log.getLogger("pfs::drp::stella::Spectra::identify")
+                        logger = log.Log.getLogger("pfs.drp.stella.Spectra.identify")
                         logger.setLevel(log.FATAL)
                         spec.identify(lineListPix, self.dispCorControl, 8)
                         self.assertTrue(False) # i.e. the previous line should raise an exception
@@ -630,19 +630,15 @@ def run(exit = False):
     #Quiet down loggers which are too verbose
     for logger in ["afw.image.ExposureInfo",
                    "CameraMapper",
-                   "extractSpectra",
-                   "FiberTraces::assignITrace",
-                   "pfs::drp::stella::FiberTrace::calcProfile",
-                   "pfs::drp::stella::FiberTrace::calcProfileSwath",
-                   "pfs::drp::stella::math::ccdToFiberTraceCoordinates",
-                   "pfs::drp::stella::math::CurveFitting::LinFitBevingtonNdArray1D",
-                   "pfs::drp::stella::math::CurveFitting::LinFitBevingtonNdArray2D",
-                   "pfs::drp::stella::math::CurfFitting::PolyFit",
-                   "pfs::drp::stella::math::psfCoordinatesRelativeTo",
-                   "pfs::drp::stella::PSF::extractPSFs",
-                   "pfs::drp::stella::PSF::extractPSFFromCenterPosition",
-                   "pfs::drp::stella::PSF::extractPSFFromCenterPositions",
-                   "pfs::drp::stella::Spectra::identify"
+                   "pfs.drp.stella.FiberTraces.assignITrace",
+                   "pfs.drp.stella.FiberTrace.calcProfile",
+                   "pfs.drp.stella.FiberTrace.calcProfileSwath",
+                   "pfs.drp.stella.math.ccdToFiberTraceCoordinates",
+                   "pfs.drp.stella.math.CurveFitting.LinFitBevingtonNdArray1D",
+                   "pfs.drp.stella.math.CurveFitting.LinFitBevingtonNdArray2D",
+                   "pfs.drp.stella.math.CurfFitting.PolyFit",
+                   "pfs.drp.stella.math.psfCoordinatesRelativeTo",
+                   "pfs.drp.stella.Spectra.identify"
                    ]:
         log.Log.getLogger(logger).setLevel(log.WARN)
 


### PR DESCRIPTION
Also fixed some typos and moved the context information out of the
log messages (as it's in the logger)