### PR TITLE
PIPE2D-296: Add SpectrumSet.plot method

### DIFF
--- a/python/pfs/drp/stella/spectraContinued.py
+++ b/python/pfs/drp/stella/spectraContinued.py
@@ -20,53 +20,139 @@ BAD_REFERENCE = (ReferenceLine.MISIDENTIFIED | ReferenceLine.CLIPPED | Reference
                  ReferenceLine.INTERPOLATED | ReferenceLine.CR)
 
 
+def plotReferenceLines(ax, referenceLines, flux, wavelength, badReference=BAD_REFERENCE):
+    """Plot reference lines on a spectrum
+
+    Parameters
+    ----------
+    ax : `matplotlib.Axes`
+        Axes on which to plot.
+    referenceLines : `list` of `pfs.drp.stella.ReferenceLine`
+        Reference lines to plot.
+    flux : `numpy.ndarray`
+        Flux vector, for setting height of reference line indicators.
+    wavelength : `numpy.ndarray`
+        Wavelength vector, for setting height of reference line indicators.
+    badReference : `pfs.drp.stella.ReferenceLine.Status`
+        Bit mask for identifying bad reference lines. Bad reference lines
+        are plotted in red instead of black.
+    """
+    minWavelength = wavelength[0]
+    maxWavelength = wavelength[-1]
+    isGood = np.isfinite(flux)
+    ff = flux[isGood]
+    wl = wavelength[isGood]
+    vertical = np.max(ff)
+    for rl in referenceLines:
+        xx = rl.wavelength
+        if xx < minWavelength or xx > maxWavelength:
+            continue
+        style = "dotted" if rl.status & ReferenceLine.RESERVED > 0 else "solid"
+        color = "red" if rl.status & badReference > 0 else "black"
+
+        index = int(np.searchsorted(wl, xx))
+        yy = np.max(ff[max(0, index - 2):min(len(ff) - 1, index + 2 + 1)])
+        ax.plot((xx, xx), (yy + 0.10*vertical, yy + 0.20*vertical), ls=style, color=color)
+        ax.text(xx, yy + 0.25*vertical, rl.description, color=color, ha='center')
+
+
 @continueClass  # noqa: F811 (redefinition)
 class Spectrum:
     """Flux as a function of wavelength"""
-    def plot(self, numRows=3, plotBackground=False, plotReferenceLines=False, badReference=BAD_REFERENCE,
+    def plot(self, numRows=3, doBackground=False, doReferenceLines=False, badReference=BAD_REFERENCE,
              filename=None):
+        """Plot spectrum
+
+        Parameters
+        ----------
+        numRows : `int`
+            Number of row panels over which to plot the spectrum.
+        doBackground : `bool`, optional
+            Plot the background values in addition to the flux values?
+        doReferenceLines : `bool`, optional
+            Plot the reference lines?
+        badReference : `pfs.drp.stella.ReferenceLine.Status`
+            Bit mask for identifying bad reference lines. Bad reference lines
+            are plotted in red instead of black.
+        filename : `str`, optional
+            Name of file to which to write the plot. If a ``filename`` is
+            specified, the matplotlib `figure` will be closed.
+
+        Returns
+        -------
+        figure : `matplotlib.figure`
+            Figure on which we plotted.
+        axes : `list` of `matplotlib.Axes`
+            Axes on which we plotted.
+        """
         import matplotlib.pyplot as plt
         figure, axes = plt.subplots(numRows)
 
         division = np.linspace(0, len(self), numRows + 1, dtype=int)[1:-1]
+        self.plotDivided(axes, division, doBackground=doBackground, doReferenceLines=doReferenceLines,
+                         badReference=badReference)
+
+        if filename is not None:
+            figure.savefig(filename, bbox_inches='tight')
+            plt.close(figure)
+        return figure, axes
+
+    def plotDivided(self, axes, division, doBackground=False, doReferenceLines=False,
+                    badReference=BAD_REFERENCE, fluxStyle=None, backgroundStyle=None):
+        """Plot spectrum that has been divided into parts
+
+        This is intended as the implementation of the guts of the ``plot``
+        method, but it may be of use elsewhere.
+
+        Parameters
+        ----------
+        axes : `list` of `matplotlib.Axes`
+            Axes on which to plot.
+        division : `numpy.ndarray`
+            Array of indices at which to divide the spectrum. This should be one
+            element shorter than the list of ``axes``.
+        doBackground : `bool`, optional
+            Plot the background values in addition to the flux values?
+        doReferenceLines : `bool`, optional
+            Plot the reference lines?
+        badReference : `pfs.drp.stella.ReferenceLine.Status`
+            Bit mask for identifying bad reference lines. Bad reference lines
+            are plotted in red instead of black.
+        fluxStyle : `dict`
+            Arguments for the ``matplotlib.Axes.plot`` method when plotting the
+            flux vector.
+        backgroundStyle : `dict`
+            Arguments for the ``matplotlib.Axes.plot`` method when plotting the
+            background vector.
+        """
+        # subplots(1) returns an Axes not embedded in a list
+        try:
+            axes[0]
+        except TypeError:
+            axes = [axes]
+
+        assert len(axes) == len(division) + 1, ("Axes/division length mismatch: %d vs %d" %
+                                                (len(axes), len(division)))
+        if fluxStyle is None:
+            fluxStyle = dict(ls="solid", color="black")
+        if backgroundStyle is None:
+            backgroundStyle = dict(ls="solid", color="blue")
+
         useWavelength = self.getWavelength()
         if np.all(useWavelength == 0.0):
             useWavelength = np.arange(len(self), dtype=np.float32)
         wavelength = np.split(useWavelength, division)
         flux = np.split(self.getSpectrum(), division)
-        if plotBackground:
+        if doBackground:
             background = np.split(self.getBackground(), division)
 
-        for ii in range(numRows):
-            ax = axes[ii]
-            ax.plot(wavelength[ii], flux[ii], 'k-')
-            if plotBackground:
-                ax.plot(wavelength[ii], background[ii], 'b-')
+        for ii, ax in enumerate(axes):
+            ax.plot(wavelength[ii], flux[ii], **fluxStyle)
+            if doBackground:
+                ax.plot(wavelength[ii], background[ii], **backgroundStyle)
             ax.set_ylim(bottom=0.0)
-            if plotReferenceLines:
-                minWavelength = wavelength[ii][0]
-                maxWavelength = wavelength[ii][-1]
-                isGood = np.isfinite(flux[ii])
-                ff = flux[ii][isGood]
-                wl = wavelength[ii][isGood]
-                vertical = np.max(ff)
-                for rl in self.getReferenceLines():
-                    xx = rl.wavelength
-                    if xx < minWavelength or xx > maxWavelength:
-                        continue
-                    style = "dotted" if rl.status & ReferenceLine.RESERVED > 0 else "solid"
-                    color = "red" if rl.status & badReference > 0 else "black"
-
-                    index = int(np.searchsorted(wl, xx))
-                    yy = np.max(ff[max(0, index - 2):min(len(ff) - 1, index + 2 + 1)])
-                    ax.plot((xx, xx), (yy + 0.10*vertical, yy + 0.20*vertical), ls=style, color=color)
-                    ax.text(xx, yy + 0.25*vertical, rl.description, color=color, ha='center')
-
-        if filename is not None:
-            plt.savefig(filename, bbox_inches='tight')
-            plt.close(figure)
-        else:
-            return plt, axes
+            if doReferenceLines:
+                plotReferenceLines(ax, self.getReferenceLines(), flux[ii], wavelength[ii], badReference)
 
 
 @continueClass  # noqa: F811 (redefinition)
@@ -277,3 +363,48 @@ class SpectrumSet:
             fiberImage = ft.constructImage(spec)
             image[fiberImage.getBBox(), afwImage.PARENT] += fiberImage
         return image
+
+    def plot(self, numRows=3, filename=None):
+        """Plot the spectra
+
+        Parameters
+        ----------
+        numRows : `int`
+            Number of row panels over which to plot the spectra.
+        filename : `str`, optional
+            Name of file to which to write the plot. If a ``filename`` is
+            specified, the matplotlib `figure` will be closed.
+
+        Returns
+        -------
+        figure : `matplotlib.figure`
+            Figure on which we plotted.
+        axes : `list` of `matplotlib.Axes`
+            Axes on which we plotted.
+        """
+        import matplotlib.cm
+        import matplotlib.pyplot as plt
+        figure, axes = plt.subplots(numRows)
+
+        minWavelength = np.min([ss.wavelength for ss in self])
+        maxWavelength = np.max([ss.wavelength for ss in self])
+        if minWavelength == 0.0 and maxWavelength == 0.0:
+            # No wavelength calibration; plot by pixel row
+            minWavelength = 0.0
+            maxWavelength = self.getLength()
+
+        colors = matplotlib.cm.rainbow(np.linspace(0, 1, len(self)))
+
+        for spectrum, cc in zip(self, colors):
+            useWavelength = spectrum.getWavelength()
+            if np.all(useWavelength == 0.0):
+                useWavelength = np.arange(len(spectrum), dtype=np.float32)
+            division = np.searchsorted(useWavelength,
+                                       np.linspace(minWavelength, maxWavelength, numRows + 1)[1:-1])
+            spectrum.plotDivided(axes, division, doBackground=False, doReferenceLines=False,
+                                 fluxStyle=dict(ls="solid", color=cc))
+
+        if filename is not None:
+            figure.savefig(filename, bbox_inches='tight')
+            plt.close(figure)
+        return figure, axes


### PR DESCRIPTION
This involves a bit of refactoring of Spectrum.plot so they can share
code. Renamed the plotBackground and plotReferenceLines kwargs to
doBackground and doReferenceLines.

SpectrumSet.plot doesn't have all the features that Spectrum.plot does,
as I decided that plotting the background and reference lines would just
make the plots too confusing.