### PR TITLE
PIPE2D-375: reduceArc: set minArcLineIntensity default to 0

### DIFF
--- a/python/pfs/drp/stella/reduceArcTask.py
+++ b/python/pfs/drp/stella/reduceArcTask.py
@@ -25,7 +25,7 @@ class ReduceArcConfig(pexConfig.Config):
     calibrateWavelengths = pexConfig.ConfigurableField(target=CalibrateWavelengthsTask,
                                                        doc="Calibrate a SpectrumSet's wavelengths")
     minArcLineIntensity = pexConfig.Field(doc="Minimum 'NIST' intensity to use emission lines",
-                                          dtype=float, default=100)
+                                          dtype=float, default=0)
 
     def setDefaults(self):
         super().setDefaults()


### PR DESCRIPTION
HgAr has many many lines below the old default value, so that reduceArc
fails on HgAr arcs without a configuration override. Ne arcs don't care
whether it's 0 or 100, so set it so that both are satisfied.