### PR TITLE
PIPE2D-411: fix pfsArm writing under reduceArc

### DIFF
--- a/python/pfs/drp/stella/SpectrumSetContinued.py
+++ b/python/pfs/drp/stella/SpectrumSetContinued.py
@@ -128,7 +128,7 @@ class SpectrumSet:
         return Struct(dirName=dirName, fileName=fileName, expId=expId, arm=arm, spectrograph=spectrograph,
                       dataId=dataId)
 
-    def writeFits(self, *args, **kwargs):
+    def writeFits(self, filename):
         """Write as FITS
 
         This is the output API for the ``FitsCatalogStorage`` storage type used
@@ -152,9 +152,9 @@ class SpectrumSet:
         NotImplementedError
             If ``hdu`` or ``flags`` arguments are provided.
         """
-        parsed = self._parsePath(*args, **kwargs)
+        parsed = self._parsePath(filename)
         pfsArm = self.toPfsArm(parsed.dataId)
-        pfsArm.write(parsed.dirName)
+        pfsArm.writeFits(filename)
 
     @classmethod
     def readFits(cls, *args, **kwargs):


### PR DESCRIPTION
The butler gives us a temporary filename that we're supposed to
write to, and then it moves it to the correct place. We were
writing to the correct place, and then the empty temporary file
was being written over the top. Instead, write to the filename
we're given.