### PR TITLE
PIPE2D-425: use dither instead of slitOffset from butler

### DIFF
--- a/python/pfs/drp/stella/constructFiberFlatTask.py
+++ b/python/pfs/drp/stella/constructFiberFlatTask.py
@@ -67,9 +67,9 @@ class ConstructFiberFlatTask(SpectralCalibTask):
         for ii, expRef in enumerate(dataRefList):
             exposure = expRef.get('postISRCCD')
 
-            slitOffset = expRef.getButler().queryMetadata("raw", "slitOffset", expRef.dataId)
-            assert len(slitOffset) == 1, "Expect a single answer for this single dataset"
-            xOffsets.append(slitOffset.pop())
+            dither = expRef.getButler().queryMetadata("raw", "dither", expRef.dataId)
+            assert len(dither) == 1, "Expect a single answer for this single dataset"
+            xOffsets.append(dither.pop())
 
             detMap = expRef.get('detectormap')
             traces = self.trace.run(exposure.maskedImage, detMap)
@@ -91,7 +91,7 @@ class ConstructFiberFlatTask(SpectralCalibTask):
                 sumFlat += exposure.maskedImage
                 sumExpect += expect
 
-        self.log.info('xOffsets = %s' % (xOffsets,))
+        self.log.info('Dither values = %s' % (xOffsets,))
         if sumFlat is None:
             raise RuntimeError("Unable to find any valid flats")
         if np.all(sumExpect.array == 0.0):

--- a/python/pfs/drp/stella/constructFiberTraceTask.py
+++ b/python/pfs/drp/stella/constructFiberTraceTask.py
@@ -15,12 +15,12 @@ class ConstructFiberTraceConfig(SpectralCalibConfig):
         target=FindAndTraceAperturesTask,
         doc="Task to trace apertures"
     )
-    requireZeroSlitOffset = Field(
+    requireZeroDither = Field(
         dtype=bool,
         default=True,
-        doc="""Require a zero slit offset value?
+        doc="""Require a zero slit dither value?
 
-        The fiber trace should have the same slit offset as the data, which is usually zero.
+        The fiber trace should have the same dither as the data, which is usually zero.
         """,
     )
     slitOffsets = ConfigField(dtype=SlitOffsetsConfig, doc="Manual slit offsets to apply to detectorMap")
@@ -41,22 +41,22 @@ class ConstructFiberTraceTask(SpectralCalibTask):
         self.makeSubtask("trace")
 
     def run(self, expRefList, butler, calibId):
-        if self.config.requireZeroSlitOffset:
+        if self.config.requireZeroDither:
             # Only run for Flats with slitOffset == 0.0
             rejected = []
             newExpRefList = []
             for expRef in expRefList:
-                slitOffset = expRef.getButler().queryMetadata("raw", "slitOffset", expRef.dataId)
-                assert len(slitOffset) == 1, "Expect a single answer for this single dataset"
-                slitOffset = slitOffset.pop()
-                if slitOffset == 0.0:
+                dither = expRef.getButler().queryMetadata("raw", "dither", expRef.dataId)
+                assert len(dither) == 1, "Expect a single answer for this single dataset"
+                dither = dither.pop()
+                if dither == 0.0:
                     newExpRefList.append(expRef)
                 else:
                     rejected.append(expRef.dataId)
             if rejected:
-                self.log.warn("Rejected the following exposures with non-zero slitOffset: %s", rejected)
-                self.log.warn("To overcome this, either set 'requireZeroSlitOffset=False' or select only "
-                              "input exposures with zero slitOffset")
+                self.log.warn("Rejected the following exposures with non-zero dither: %s", rejected)
+                self.log.warn("To overcome this, either set 'requireZeroDither=False' or select only "
+                              "input exposures with zero dither")
             expRefList = newExpRefList
 
         if not expRefList:


### PR DESCRIPTION
The hexapod position along the slit is now called 'dither' instead
of 'slitOffset'. slitOffset hasn't been set to actual values since
the camera stopped writing W_FCA_DITHER. dither gets its values
from a new header keyword.