### PR TITLE
DAMD-61: changed file mode "w" to "wb"

### DIFF
--- a/python/pfs/drp/stella/fitFocalPlane.py
+++ b/python/pfs/drp/stella/fitFocalPlane.py
@@ -68,7 +68,7 @@ class FocalPlaneFunction(types.SimpleNamespace):
         """
         fits = astropy.io.fits.HDUList()
         fits.append(astropy.io.fits.ImageHDU(self.vector))
-        with open(filename, "w") as fd:
+        with open(filename, "wb") as fd:
             fits.writeto(fd)
 
 

--- a/python/pfs/drp/stella/subtractSky1d.py
+++ b/python/pfs/drp/stella/subtractSky1d.py
@@ -79,7 +79,7 @@ class SubtractSky1DSolution(types.SimpleNamespace):
         fits = astropy.io.fits.HDUList()
         fits.append(astropy.io.fits.ImageHDU(self.wavelength))
         fits.append(astropy.io.fits.ImageHDU(self.flux))
-        with open(filename, "w") as fd:
+        with open(filename, "wb") as fd:
             fits.writeto(fd)
 
 


### PR DESCRIPTION
Changed open(..., "w") to open(..., "wb") for files that FITS data are
written on. Not only is it logically wrong to use the text mode here,
but it is also forbidden in astropy 3.2.