### PR TITLE
PIPE2D-536: Correct header info for ReduceArc and BootstrapDetectorMap

### DIFF
--- a/python/pfs/drp/stella/bootstrap.py
+++ b/python/pfs/drp/stella/bootstrap.py
@@ -165,6 +165,7 @@ class BootstrapTask(CmdLineTask):
         """
         metadata = arcRef.get("raw_md")
         lamps = getLampElements(metadata)
+        self.log.info("Arc lamp elements are: %s", " ".join(lamps))
         if not lamps:
             raise RuntimeError("No lamps found from metadata")
         return readLineListFile(lineListFilename, lamps, minIntensity=self.config.minArcLineIntensity)


### PR DESCRIPTION
Added log message to indicate which lamps are on for the data in question.
