### PR TITLE
PIPE2D-541: Prevent constructFiberTrace from operating on different fiber configurations

### DIFF
--- a/python/pfs/drp/stella/coaddSpectra.py
+++ b/python/pfs/drp/stella/coaddSpectra.py
@@ -271,8 +271,8 @@ class CoaddSpectraTask(CmdLineTask):
             with np.errstate(invalid="ignore", divide="ignore"):
                 good = ((ss.mask & ss.flags.get(*self.config.mask)) == 0) & (ss.covar[0] > 0)
                 weight[good] = 1.0/ss.covar[0][good]
-                flux += ss.flux*weight
-                sky += ss.sky*weight
+                flux[good] += ss.flux[good]*weight[good]
+                sky[good] += ss.sky[good]*weight[good]
                 mask[good] |= ss.mask[good]
                 sumWeights += weight
 

--- a/python/pfs/drp/stella/coaddSpectra.py
+++ b/python/pfs/drp/stella/coaddSpectra.py
@@ -22,7 +22,8 @@ class CoaddSpectraConfig(Config):
     wavelength = ConfigField(dtype=WavelengthSamplingConfig, doc="Wavelength configuration")
     subtractSky1d = ConfigurableField(target=SubtractSky1dTask, doc="1d sky subtraction")
     measureFluxCalibration = ConfigurableField(target=MeasureFluxCalibrationTask, doc="Flux calibration")
-    mask = ListField(dtype=str, default=["NO_DATA", "CR"], doc="Mask values to reject when combining")
+    mask = ListField(dtype=str, default=["NO_DATA", "CR", "BAD_FLUXCAL"],
+                     doc="Mask values to reject when combining")
     fluxTable = ConfigurableField(target=FluxTableTask, doc="Flux table")
 
 

--- a/python/pfs/drp/stella/constructFiberTraceTask.py
+++ b/python/pfs/drp/stella/constructFiberTraceTask.py
@@ -1,13 +1,26 @@
 import numpy as np
+from collections import defaultdict
 
 import lsst.daf.base as dafBase
 import lsst.afw.display as afwDisplay
 import lsst.afw.image as afwImage
 from lsst.pex.config import Field, ConfigurableField, ConfigField
+from lsst.pipe.drivers.constructCalibs import CalibTaskRunner
 from .constructSpectralCalibs import SpectralCalibConfig, SpectralCalibTask
 from .findAndTraceAperturesTask import FindAndTraceAperturesTask
 from pfs.drp.stella import Spectrum, SlitOffsetsConfig
 from pfs.drp.stella.fitContinuum import FitContinuumTask
+
+
+class ConstructFiberTraceTaskRunner(CalibTaskRunner):
+    """Split values with different pfsDesignId"""
+    @staticmethod
+    def getTargetList(parsedCmd, **kwargs):
+        pfsDesignId = defaultdict(list)
+        for dataRef in parsedCmd.id.refList:
+            pfsDesignId[dataRef.dataId["pfsDesignId"]].append(dataRef)
+        return [dict(expRefList=expRefList, butler=parsedCmd.butler, calibId=parsedCmd.calibId) for
+                expRefList in pfsDesignId.values()]
 
 
 class ConstructFiberTraceConfig(SpectralCalibConfig):
@@ -37,6 +50,7 @@ class ConstructFiberTraceTask(SpectralCalibTask):
     ConfigClass = ConstructFiberTraceConfig
     _DefaultName = "fiberTrace"
     calibName = "fiberTrace"
+    RunnerClass = ConstructFiberTraceTaskRunner
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/python/pfs/drp/stella/constructFiberTraceTask.py
+++ b/python/pfs/drp/stella/constructFiberTraceTask.py
@@ -7,6 +7,7 @@ from lsst.pex.config import Field, ConfigurableField, ConfigField
 from .constructSpectralCalibs import SpectralCalibConfig, SpectralCalibTask
 from .findAndTraceAperturesTask import FindAndTraceAperturesTask
 from pfs.drp.stella import Spectrum, SlitOffsetsConfig
+from pfs.drp.stella.fitContinuum import FitContinuumTask
 
 
 class ConstructFiberTraceConfig(SpectralCalibConfig):
@@ -24,6 +25,7 @@ class ConstructFiberTraceConfig(SpectralCalibConfig):
         """,
     )
     slitOffsets = ConfigField(dtype=SlitOffsetsConfig, doc="Manual slit offsets to apply to detectorMap")
+    fitContinuum = ConfigurableField(target=FitContinuumTask, doc="Fit continuum")
 
     def setDefaults(self):
         super().setDefaults()
@@ -39,6 +41,7 @@ class ConstructFiberTraceTask(SpectralCalibTask):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.makeSubtask("trace")
+        self.makeSubtask("fitContinuum")
 
     def run(self, expRefList, butler, calibId):
         if self.config.requireZeroDither:

--- a/python/pfs/drp/stella/constructSpectralCalibs.py
+++ b/python/pfs/drp/stella/constructSpectralCalibs.py
@@ -10,7 +10,6 @@ from lsst.ctrl.pool.pool import NODE
 import lsst.pipe.drivers.constructCalibs
 from lsst.pipe.drivers.utils import getDataRef
 from lsst.pipe.tasks.repair import RepairTask
-from pfs.drp.stella.fitContinuum import FitContinuumTask
 
 __all__ = ["SpectralCalibConfig", "SpectralCalibTask"]
 
@@ -121,7 +120,6 @@ class SpectralCalibConfig(lsst.pipe.drivers.constructCalibs.CalibConfig):
         target=RepairTask,
         doc="Task to repair artifacts"
     )
-    fitContinuum = ConfigurableField(target=FitContinuumTask, doc="Fit continuum")
 
 
 class SpectralCalibTask(lsst.pipe.drivers.constructCalibs.CalibTask):
@@ -136,7 +134,6 @@ class SpectralCalibTask(lsst.pipe.drivers.constructCalibs.CalibTask):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.makeSubtask("repair")
-        self.makeSubtask("fitContinuum")
         import lsstDebug
         self.debugInfo = lsstDebug.Info(__name__)
 

--- a/python/pfs/drp/stella/datamodel/pfsFiberArray.py
+++ b/python/pfs/drp/stella/datamodel/pfsFiberArray.py
@@ -123,7 +123,7 @@ class PfsFiberArray(pfs.datamodel.PfsFiberArray, PfsSimpleSpectrum):
             Resampled spectrum.
         """
         flux = interpolateFlux(self.wavelength, self.flux, wavelength)
-        mask = interpolateMask(self.wavelength, self.mask, wavelength)
+        mask = interpolateMask(self.wavelength, self.mask, wavelength, fill=self.flags.get("NO_DATA"))
         sky = interpolateFlux(self.wavelength, self.sky, wavelength)
         covar = np.array([interpolateFlux(self.wavelength, cc, wavelength) for cc in self.covar])
         covar2 = np.array([[0]])  # Not sure what to put here

--- a/tests/test_FluxTable.py
+++ b/tests/test_FluxTable.py
@@ -69,9 +69,12 @@ class FluxTableTestCase(lsst.utils.tests.TestCase):
         """Test resample method"""
         wavelength = np.linspace(self.minWavelength, self.maxWavelength, self.length)
         resampled = self.fluxTable.resample(wavelength)
+        missing = resampled.flags.get("missing")
         nodata = resampled.flags.get("NO_DATA")
         self.assertFloatsEqual(resampled.wavelength, wavelength)
-        self.assertGreater(((resampled.mask & nodata) != 0).sum(), 0)
+        self.assertGreater(((resampled.mask & missing) != 0).sum(),
+                           ((self.fluxTable.mask & self.fluxTable.flags.get("missing") != 0).sum()))
+        self.assertFalse(np.any((resampled.mask & nodata) != 0))
         self.assertGreater((resampled.flux > 0).sum(), 0)
 
 


### PR DESCRIPTION
I also fixed some interpolation problems I noticed.