### PR TITLE
PIPE2D-746: Remove all explicit mention of afwDisplay backend

### DIFF
--- a/python/pfs/drp/stella/DetectorMapContinued.py
+++ b/python/pfs/drp/stella/DetectorMapContinued.py
@@ -224,7 +224,6 @@ class DetectorMap:
 
 class DisplayDetectorMapConfig(Config):
     """Configuration for DisplayDetectorMapTask"""
-    backend = Field(dtype=str, default="ds9", doc="Display backend to use")
     frame = Field(dtype=int, default=1, doc="Frame to use for display")
     doPlotLines = Field(dtype=bool, default=True, doc="Plot the location of lines from line list?")
     readLineList = ConfigurableField(target=ReadLineListTask, doc="Read line list")
@@ -277,7 +276,7 @@ class DisplayDetectorMapTask(CmdLineTask):
             lines = self.readLineList.run(metadata=exposure.getMetadata())
             wavelengths = [rl.wavelength for rl in lines]
 
-        display = Display(backend=self.config.backend, frame=self.config.frame)
+        display = Display(frame=self.config.frame)
         display.mtv(exposure)
 
         goodFibers = detectorMap.fiberId[pfsConfig.selectByFiberStatus(pfs.datamodel.FiberStatus.GOOD,

--- a/python/pfs/drp/stella/bootstrap.py
+++ b/python/pfs/drp/stella/bootstrap.py
@@ -502,9 +502,8 @@ class BootstrapTask(CmdLineTask):
         if not lsstDebug.Info(__name__).visualize:
             return
         from lsst.afw.display import Display
-        backend = "ds9"
         top = 50
-        disp = Display(frame, backend)
+        disp = Display(frame)
         disp.mtv(image)
 
         wlArrays = np.array([detectorMap.getWavelength(ff) for ff in fiberId])

--- a/python/pfs/drp/stella/buildFiberProfiles.py
+++ b/python/pfs/drp/stella/buildFiberProfiles.py
@@ -18,7 +18,6 @@ import lsstDebug
 
 __all__ = ("BuildFiberProfilesConfig", "BuildFiberProfilesTask")
 
-backend = "ds9"
 colors = ["red", "green", "blue", "cyan", "magenta", "yellow", "orange"]
 
 
@@ -151,10 +150,10 @@ class BuildFiberProfilesTask(Task):
             SpanSet.fromMask(mask, bitmask).dilated(grow).clippedTo(mask.getBBox()).setMask(mask, bitmask)
 
         if self.debugInfo.displayConvolved:
-            Display(backend=backend, frame=1).mtv(convolvedImage)
+            Display(frame=1).mtv(convolvedImage)
             sigNoise = convolvedImage.clone()
             sigNoise.image.array /= np.sqrt(convolvedImage.variance.array)
-            Display(backend=backend, frame=2).mtv(sigNoise)
+            Display(frame=2).mtv(sigNoise)
 
         return convolvedImage
 
@@ -179,7 +178,7 @@ class BuildFiberProfilesTask(Task):
         spans.setMask(mask, bitmask)
 
         if self.debugInfo.findPeaks:
-            display = Display(backend=self.debugInfo.backend, frame=self.debugInfo.frame or 1)
+            display = Display(frame=self.debugInfo.frame or 1)
             display.setMaskPlaneColor("FIBERTRACE", "blue")
             display.mtv(maskedImage)
             with display.Buffering():
@@ -287,7 +286,7 @@ class BuildFiberProfilesTask(Task):
                 association[pp.low:pp.high + 1, layer] = index
 
         if self.debugInfo.associatePeaks:
-            display = Display(backend=backend, frame=1)
+            display = Display(frame=1)
             for tt, cc in zip(traces, itertools.cycle(colors)):
                 with display.Buffering():
                     for pp in tt:
@@ -486,7 +485,7 @@ class BuildFiberProfilesTask(Task):
                 self.log.warn("Failed to identify %d fiberIds: %s", len(notFound), sorted(notFound))
 
         if self.debugInfo.identifyFibers:
-            display = Display(backend=backend, frame=1)
+            display = Display(frame=1)
             for fiberId in profiles:
                 display.dot(str(fiberId), centers[fiberId](middle), middle, ctype="green")
             for fiberId in detectorMap.fiberId:

--- a/python/pfs/drp/stella/centroidLines.py
+++ b/python/pfs/drp/stella/centroidLines.py
@@ -125,7 +125,7 @@ class CentroidLinesTask(Task):
 
         if self.debugInfo.displayConvolved:
             from lsst.afw.display import Display
-            Display(backend=self.debugInfo.backend or "ds9", frame=1).mtv(convolvedImage)
+            Display(frame=1).mtv(convolvedImage)
 
         return convolvedImage
 
@@ -273,8 +273,6 @@ class CentroidLinesTask(Task):
         The display is controlled by debug parameters:
         - ``display`` (`bool`): Enable display?
         - ``frame`` (`int`, optional): Frame to use for display (defaults to 1).
-        - ``backend`` (`str`, optional): Backend to use for display (defaults to
-          ``ds9``).
 
         Parameters
         ----------
@@ -286,7 +284,7 @@ class CentroidLinesTask(Task):
         if not self.debugInfo.display:
             return
         from lsst.afw.display import Display
-        disp = Display(frame=self.debugInfo.frame or 1, backend=self.debugInfo.backend or "ds9")
+        disp = Display(frame=self.debugInfo.frame or 1)
         disp.mtv(exposure)
         with disp.Buffering():
             for row in catalog:

--- a/python/pfs/drp/stella/measureSlitOffsets.py
+++ b/python/pfs/drp/stella/measureSlitOffsets.py
@@ -234,7 +234,6 @@ class MeasureSlitOffsetsTask(Task):
 
         The following debug parameters are used:
         - ``frame`` (`int`): display frame to use (defaults to ``1``).
-        - ``backend`` (`str`): display backend to use (defaults to ``"ds9"``).
 
         Parameters
         ----------
@@ -254,7 +253,7 @@ class MeasureSlitOffsetsTask(Task):
             Wavelengths to mark.
         """
         from lsst.afw.display import Display
-        disp = Display(frame=self.debugInfo.frame or 1, backend=self.debugInfo.backend or "ds9")
+        disp = Display(frame=self.debugInfo.frame or 1)
         disp.mtv(exposure)
         with disp.Buffering():
             for line in centroids:

--- a/python/pfs/drp/stella/reduceArc.py
+++ b/python/pfs/drp/stella/reduceArc.py
@@ -138,7 +138,6 @@ class ReduceArcTask(CmdLineTask):
         - ``display`` (`bool`): Activate displays and plotting (master switch)?
         - ``frame`` (`dict` mapping `int` to `int`): Display frame to use as a
             function of visit.
-        - ``backend`` (`str`): Display backend name.
         - ``displayIdentifications`` (`bool`): Display image with lines
             identified?
         - ``displayCalibrations`` (`bool`): Plot calibration results? See the
@@ -172,7 +171,7 @@ class ReduceArcTask(CmdLineTask):
         self.identifyLines.run(spectra, detectorMap, lines)
         if self.debugInfo.display and self.debugInfo.displayIdentifications:
             frame = self.debugInfo.frame[dataRef.dataId["visit"]] if self.debugInfo.frame is not None else 1
-            self.plotIdentifications(self.debugInfo.backend or "ds9", exposure, spectra, detectorMap, frame)
+            self.plotIdentifications(exposure, spectra, detectorMap, frame)
         referenceLines = self.centroidLines.getReferenceLines(spectra)
         lines = self.centroidLines.run(exposure, referenceLines, detectorMap)
         dataRef.put(lines, "arcLines")
@@ -268,7 +267,7 @@ class ReduceArcTask(CmdLineTask):
         """
         return sorted(dataRefList, key=lambda dataRef: dataRef.dataId["visit"])[0]
 
-    def plotIdentifications(self, backend, exposure, spectrumSet, detectorMap, frame=1):
+    def plotIdentifications(self, exposure, spectrumSet, detectorMap, frame=1):
         """Plot line identifications
 
         Parameters
@@ -280,7 +279,7 @@ class ReduceArcTask(CmdLineTask):
         detectorMap : `pfs.drp.stella.utils.DetectorMap`
             Mapping of wl,fiber to detector position.
         """
-        display = afwDisplay.Display(frame, backend=backend)
+        display = afwDisplay.Display(frame)
         display.mtv(exposure)
         for spec in spectrumSet:
             fiberId = spec.getFiberId()


### PR DESCRIPTION
Please use afwDisplay.setDefaultBackend() instead