### PR TITLE
PIPE2D-868: SpectrumSet.makeImage asserts len(self) == len(fiberTraces) which fails with broken fibres

### DIFF
--- a/python/pfs/drp/stella/SpectrumSetContinued.py
+++ b/python/pfs/drp/stella/SpectrumSetContinued.py
@@ -205,7 +205,6 @@ class SpectrumSet:
         """
         image = afwImage.ImageF(box)
         image.set(0.0)
-        assert len(self) == len(fiberTraces), "Number of spectra and fiberTraces don't match"
 
         fiberIds = list(self.getAllFiberIds())
         for ft in fiberTraces:


### PR DESCRIPTION
One liner