### PR TITLE
PIPE2D-849: coaddSpectra: only consider targets with existing data

### DIFF
--- a/python/pfs/drp/stella/coaddSpectra.py
+++ b/python/pfs/drp/stella/coaddSpectra.py
@@ -46,7 +46,10 @@ class CoaddSpectraRunner(TaskRunner):
 
         dataRefs = {dataRefToTuple(ref): ref for ref in parsedCmd.id.refList}
         for ref in parsedCmd.id.refList:
+            if not all(ref.datasetExists(dataset) for dataset in ("pfsArm", "sky1d", "fluxCal")):
+                continue
             pfsConfig = ref.get("pfsConfig")
+            pfsConfig = pfsConfig.select(spectrograph=ref.dataId["spectrograph"])
             for index, fiberStatus in enumerate(pfsConfig.fiberStatus):
                 if fiberStatus != FiberStatus.GOOD:
                     continue


### PR DESCRIPTION
pfsConfig now includes targets for all spectrographs. If we
haven't processed data from all spectrographs, we can't
coadd those targets, so don't consider them.