### PR TITLE
PIPE2D-920: Change location of broadband photometry table for FitBroadbandSEDTask

### DIFF
--- a/python/pfs/drp/stella/fitBroadbandSED.py
+++ b/python/pfs/drp/stella/fitBroadbandSED.py
@@ -17,8 +17,6 @@ class FitBroadbandSEDConfig(Config):
 
     fluxLibraryPath = Field(
         dtype=str,
-        default=os.path.join(getPackageDir("drp_pfs_data"), "fluxCalibration",
-                             "syntheticFlux_withInterp_ps_HSCPS1GaiaSDSS.fits"),
         doc="Synthetic photometry table"
     )
 
@@ -30,6 +28,22 @@ class FitBroadbandSEDConfig(Config):
         },
         doc="Conversion table from pfsConfig's filter names to those used by `fluxLibrary`"
     )
+
+    def setDefaults(self):
+        super().setDefaults()
+
+        try:
+            dataDir = getPackageDir("fluxmodeldata")
+        except LookupError:
+            # We don't make this an exception because this method is called
+            # even when `fluxLibraryPath` is specified in a call to the
+            # constructor.
+            dataDir = None
+
+        if dataDir is not None:
+            self.fluxLibraryPath = os.path.join(
+                dataDir, "broadband", "photometries.fits"
+            )
 
 
 class FitBroadbandSEDTask(Task):

--- a/tests/test_fitBroadbandSED.py
+++ b/tests/test_fitBroadbandSED.py
@@ -1,12 +1,21 @@
 import lsst.utils.tests
 
+import lsst.utils
 from pfs.drp.stella.fitBroadbandSED import FitBroadbandSEDConfig, FitBroadbandSEDTask
 from pfs.drp.stella.tests import runTests
 from pfs.datamodel.pfsConfig import FiberStatus, PfsConfig, TargetType
 
 import numpy
 
+import unittest
 
+try:
+    dataDir = lsst.utils.getPackageDir("fluxmodeldata")
+except LookupError:
+    dataDir = None
+
+
+@unittest.skipIf(dataDir is None, "fluxmodeldata not setup")
 class FitBroadbandSEDTestCase(lsst.utils.tests.TestCase):
     def setUp(self):
         self.fitBroadbandSED = FitBroadbandSEDTask(config=FitBroadbandSEDConfig())

--- a/ups/drp_stella.table
+++ b/ups/drp_stella.table
@@ -8,6 +8,7 @@ setupRequired(datamodel)
 setupRequired(sconsUtils)
 setupRequired(pybind11)
 setupRequired(ip_isr)
+setupOptional(fluxmodeldata)
 
 envPrepend(PATH, ${PRODUCT_DIR}/bin)
 


### PR DESCRIPTION
The broadband photometry table is now included in `fluxmodeldata`
package together with the synthetic spectra from which the b.b.
photometries derive.