### PR TITLE
PIPE2D-967: showDetectorMap - fix call to pfsConfig.selectFiber()

### DIFF
--- a/python/pfs/drp/stella/utils/display.py
+++ b/python/pfs/drp/stella/utils/display.py
@@ -240,7 +240,7 @@ def showDetectorMap(display, pfsConfig, detMap, width=100, zoom=0, xc=None, fibe
         alpha = 0.5 if showAll else 1.0
         ls = '-'
         if fid in pfsConfig.fiberId:
-            ind = pfsConfig.selectFiber(fid)[0]
+            ind = pfsConfig.selectFiber(fid)
             imagingFiber = pfsConfig.targetType[ind] == TargetType.SUNSS_IMAGING
             if pfsConfig.fiberStatus[ind] == FiberStatus.BROKENFIBER:
                 ls = ':'


### PR DESCRIPTION
pfsConfig.selectFiber() returns a scalar int value if the input argument
is also a scalar. This is how it is used in showDetectorMap.