### PR TITLE
PIPE2D-987: Make fitPfsFluxReference consider Galactic extinction

### DIFF
--- a/python/pfs/drp/stella/dustMap.py
+++ b/python/pfs/drp/stella/dustMap.py
@@ -1,0 +1,103 @@
+import lsst.utils
+
+import astropy.coordinates
+import astropy.io.fits
+import astropy.units
+import astropy.wcs
+import numpy as np
+import scipy.interpolate
+
+import os
+
+__all__ = ("DustMap",)
+
+
+class DustMap:
+    """Dust extinction map E(B-V)
+
+    Parameters
+    ----------
+    filenames : `list` of `str`, optional
+        Paths to FITS files containing E(B-V).
+        Must be of length 2 if not None,
+        one file for the northern hemisphere
+        and the other for the southern hemisphere.
+        Uses ``dustmaps_cachedata`` package by default.
+    kx : `int`, optional
+        Degrees of the bivariate spline. Default is 1.
+    ky : `int`, optional
+        Degrees of the bivariate spline. Default is 1.
+    """
+    def __init__(self, filenames=None, kx=1, ky=1):
+        if not filenames:
+            dataDir = lsst.utils.getPackageDir("dustmaps_cachedata")
+            filenames = [
+                os.path.join(dataDir, "data", "sfd", "SFD_dust_4096_ngp.fits"),
+                os.path.join(dataDir, "data", "sfd", "SFD_dust_4096_sgp.fits"),
+            ]
+        if len(filenames) != 2:
+            raise ValueError(
+                f"Two and only two dustmap files must be given, but {len(filenames)} file(s) are given."
+            )
+        with astropy.io.fits.open(filenames[0]) as hdus:
+            hdu = hdus[0]
+            self.ngpWcs = astropy.wcs.WCS(hdu.header)
+            self.ngpImage = scipy.interpolate.RectBivariateSpline(
+                np.linspace(1, hdu.data.shape[0], hdu.data.shape[0], endpoint=True, dtype=float),
+                np.linspace(1, hdu.data.shape[1], hdu.data.shape[1], endpoint=True, dtype=float),
+                hdu.data.astype(float),
+                kx=kx,
+                ky=ky,
+                s=0,
+            )
+        with astropy.io.fits.open(filenames[1]) as hdus:
+            hdu = hdus[0]
+            self.sgpWcs = astropy.wcs.WCS(hdu.header)
+            self.sgpImage = scipy.interpolate.RectBivariateSpline(
+                np.linspace(1, hdu.data.shape[0], hdu.data.shape[0], endpoint=True, dtype=float),
+                np.linspace(1, hdu.data.shape[1], hdu.data.shape[1], endpoint=True, dtype=float),
+                hdu.data.astype(float),
+                kx=kx,
+                ky=ky,
+                s=0,
+            )
+
+    def __call__(self, ra, dec):
+        """Get E(B-V) at (ra, dec) in ICRS coordinates
+
+        Parameters
+        ----------
+        ra : `float` or `numpy.array` or `astropy.units.quantity.Quantity`
+            R.A. in degrees by default.
+        dec : `float` or `numpy.array` or `astropy.units.quantity.Quantity`
+            Dec. in degrees by default.
+
+        Returns
+        -------
+        ebv : `numpy.array`
+            E(B-V)
+        """
+        # convert (ra, dec) to (l, b) (galactic coordinates)
+        if not isinstance(ra, astropy.units.quantity.Quantity):
+            ra = np.asarray(ra, dtype=float) * astropy.units.degree
+        if not isinstance(dec, astropy.units.quantity.Quantity):
+            dec = np.asarray(dec, dtype=float) * astropy.units.degree
+        gal = astropy.coordinates.SkyCoord(ra, dec, frame="icrs").galactic
+        gall = np.asarray(gal.l.degree)
+        galb = np.asarray(gal.b.degree)
+
+        # allocate an array in which to store E(B-V)
+        ebv = np.full(shape=gall.shape, fill_value=np.nan, dtype=float)
+
+        # northern hemisphere
+        index = (galb >= 0)
+        if np.any(index):
+            x, y = self.ngpWcs.wcs_world2pix(gall[index], galb[index], 1.0)
+            ebv[index] = self.ngpImage(y, x, grid=False)
+        # southern hemisphere
+        index = (galb < 0)
+        if np.any(index):
+            x, y = self.sgpWcs.wcs_world2pix(gall[index], galb[index], 1.0)
+            ebv[index] = self.sgpImage(y, x, grid=False)
+
+        return ebv

--- a/python/pfs/drp/stella/extinctionCurve.py
+++ b/python/pfs/drp/stella/extinctionCurve.py
@@ -1,0 +1,158 @@
+import numpy as np
+from scipy import interpolate
+
+import abc
+
+__all__ = ("ExtinctionCurve", "F99ExtinctionCurve")
+
+
+class ExtinctionCurve(metaclass=abc.ABCMeta):
+    """Dust extinction curve.
+
+    This is an abstract base class.
+    ``_extinction()`` method must be overridden in subclasses.
+    """
+
+    def attenuation(self, wavelength, ebv):
+        """A(lambda) converted to fractional extinction.
+
+        To get a spectrum attenuated, multiply it by this.
+        To correct an attenuated spectrum, divide it by this.
+
+        Parameters
+        ----------
+        wavelength : `numpy.array`
+            Wavelength in nm.
+        ebv : `float`
+            E(B-V).
+
+        Returns
+        -------
+        att : `numpy.array`
+            Fractional extinction
+        """
+        att = 10**(-0.4 * self._extinction(wavelength, ebv))
+        return att
+
+    @abc.abstractmethod
+    def _extinction(self, wavelength, ebv):
+        """Get the extinction as a function of wavelength, A(lambda)
+        using a specific extinction curve model.
+
+        Subclasses must override this method.
+
+        Parameters
+        ----------
+        wavelength : `numpy.array`
+            Wavelength in nm.
+        ebv : `float`
+            E(B-V).
+
+        Returns
+        -------
+        ax : `numpy.array'
+            Extinction as a function of wavelength, A(lambda) (magnitude).
+        """
+        raise NotImplementedError()
+
+
+class F99ExtinctionCurve(ExtinctionCurve):
+    """Fitzpatrick (1999) extinction curve.
+    (Bibcode: 1999PASP..111...63F)
+
+    Parameters
+    ----------
+    Rv : `float`
+        Ratio of total to selective extinction at V, Rv = A(V)/E(B-V).
+        Default is 3.1.
+    """
+
+    xAnchorF99 = np.array([0., 0.377, 0.820, 1.667, 1.828, 2.141, 2.433, 3.704, 3.846], dtype=float)
+    """spline anchors taken from F99, micron^-1, from IR to UV
+    """
+
+    def __init__(self, Rv=3.1):
+        super().__init__()
+        self._Rv = Rv
+
+        yAnchorUV = self._fm90(self.xAnchorF99[7:])
+        yAnchorIR = np.array([0., 0.265, 0.829], dtype=float) * (Rv / 3.1)
+        yAnchorOpt = np.array([
+            -0.426 + 1.0044 * Rv,
+            -0.050 + 1.0016 * Rv,
+            0.701 + 1.0016 * Rv,
+            1.208 + 1.0032 * Rv - 0.00033 * Rv**2
+        ], dtype=float)
+        yAnchorF99 = np.concatenate((yAnchorIR, yAnchorOpt, yAnchorUV))
+
+        self.interpolator = interpolate.splrep(self.xAnchorF99, yAnchorF99, k=3, s=0)
+
+    def _extinction(self, wavelength, ebv):
+        """Get the extinction as a function of wavelength, A(lambda).
+
+        Parameters
+        ----------
+        wavelength : `numpy.array` of `float`
+            Wavelength in nm.
+        ebv : `float`
+            E(B-V).
+
+        Returns
+        -------
+        ax : `numpy.array` of `float`
+            Extinction as a function of wavelength, A(lambda) (magnitude).
+        """
+        x = 1. / (wavelength*1e-3)  # micron^(-1)
+        axebv = interpolate.splev(x, self.interpolator)
+        ax = axebv * ebv
+        return ax
+
+    def _fm90(self, x):
+        """UV extinction curve of Fitzpatrick & Massa (1990)
+        (Bibcode: 1990ApJS...72..163F)
+
+        Parameters
+        ----------
+        x : `numpy.array` of `float`
+            1/wavelength (micron^-1).
+
+        Returns
+        -------
+        uvCurveAxebv : `numpy.array` of `float`
+            Extinction curve, A(lamba)/E(B-V).
+        """
+        x = np.asarray(x, dtype='float')
+        c2 = -0.824 + 4.717 / self._Rv
+        c1 = 2.030 - 3.007 * c2
+        x0 = 4.596
+        gamma = 0.99
+        c3 = 3.23
+        c4 = 0.41
+
+        linearTerm = c1 + c2 * x
+        drudeTerm = x**2 / ((x**2 - x0**2)**2 + (x**2) * gamma**2)
+
+        # no term for Far-UV because x must be less than 5.9 micron^-1
+        fuvTerm = 0.
+
+        uvCurve = (
+            linearTerm +
+            c3 * drudeTerm +
+            c4 * fuvTerm
+        )  # E(lambda-V)/E(B-V)
+
+        # convert E(lambda-V)/E(B-V) to A(lambda)/E(B-V)
+        return uvCurve + self._Rv
+
+    @property
+    def Rv(self):
+        """Ratio of total to selective extinction at V, Rv = A(V)/E(B-V)
+
+        This property is read-only.
+
+        Returns
+        -------
+        Rv : `float`
+            Rv = A(V)/E(B-V).
+        """
+        return self._Rv

--- a/tests/test_dustMap.py
+++ b/tests/test_dustMap.py
@@ -1,0 +1,49 @@
+import lsst.utils.tests
+
+import lsst.utils
+from pfs.drp.stella.dustMap import DustMap
+from pfs.drp.stella.tests import runTests
+
+import astropy.units
+import numpy as np
+
+import unittest
+
+try:
+    dataDir = lsst.utils.getPackageDir("dustmaps_cachedata")
+except LookupError:
+    dataDir = None
+
+
+@unittest.skipIf(dataDir is None, "dustmaps_cachedata not setup")
+class DustMapTestCase(lsst.utils.tests.TestCase):
+    def setUp(self):
+        self.dustMap = DustMap()
+
+    def test(self):
+        """Test __call__()
+        """
+        ralist = np.linspace(0, 360, 5, dtype=float)
+        declist = np.linspace(-90, 90, 5, dtype=float)
+
+        # calls with scalar arguments
+        result1 = [self.dustMap(float(ra), float(dec)) for ra, dec in zip(ralist, declist)]
+        result1 = np.asarray(result1)
+
+        # call with numpy arrays
+        result2 = self.dustMap(ralist, declist)
+
+        # call with astropy.units.quantity.Quantity
+        result3 = self.dustMap(ralist * astropy.units.degree, declist * astropy.units.degree)
+
+        # I don't know why, but these two results are not quite equal.
+        self.assertFloatsAlmostEqual(result1, result2, rtol=3e-14)
+        self.assertFloatsAlmostEqual(result2, result3)
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    runTests(globals())

--- a/tests/test_extinctionCurve.py
+++ b/tests/test_extinctionCurve.py
@@ -1,0 +1,39 @@
+import lsst.utils.tests
+from pfs.drp.stella.extinctionCurve import F99ExtinctionCurve
+from pfs.drp.stella.tests import runTests
+
+import numpy as np
+
+
+class F99ExtinctionCurveTestCase(lsst.utils.tests.TestCase):
+    def setUp(self):
+        self.extinctionCurve = F99ExtinctionCurve()
+
+    def testAttenuation(self):
+        """Test attenuation()
+        """
+        # Table 3 in Fitzpatrick (1999)
+        reference = np.array([
+            (260, 6.591),
+            (270, 6.265),
+            (411, 4.315),
+            (467, 3.806),
+            (547, 3.055),
+            (600, 2.688),
+            (1220, 0.829),
+            (2650, 0.265),
+        ], dtype=[("lambda", float), ("A(lambda)/E(B-V)", float)])
+
+        ebv = 0.2
+        att = self.extinctionCurve.attenuation(reference["lambda"], ebv)
+        aOverE = (-2.5 * np.log10(att)) / ebv
+
+        self.assertFloatsAlmostEqual(aOverE, reference["A(lambda)/E(B-V)"], atol=2e-3)
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    runTests(globals())

--- a/tests/test_fitPfsFluxReference.py
+++ b/tests/test_fitPfsFluxReference.py
@@ -1,0 +1,310 @@
+import lsst.utils.tests
+import lsst.utils
+from pfs.drp.stella.tests import runTests
+
+from pfs.datamodel.identity import Identity
+from pfs.datamodel.masks import MaskHelper
+from pfs.datamodel.pfsConfig import FiberStatus, PfsConfig, TargetType
+from pfs.datamodel.pfsFiberArraySet import PfsFiberArraySet
+from pfs.datamodel.pfsSimpleSpectrum import PfsSimpleSpectrum
+from pfs.datamodel.target import Target
+from pfs.drp.stella.dustMap import DustMap
+from pfs.drp.stella.extinctionCurve import F99ExtinctionCurve
+from pfs.drp.stella.fitPfsFluxReference import FitPfsFluxReferenceTask, FitPfsFluxReferenceConfig
+from pfs.drp.stella.fitReference import FilterCurve
+from pfs.drp.stella.fluxModelSet import FluxModelSet
+from pfs.drp.stella.interpolate import interpolateFlux
+from pfs.drp.stella.lsf import GaussianKernel1D
+from pfs.drp.stella.utils.psf import fwhmToSigma
+
+import numpy as np
+
+import unittest
+
+try:
+    fluxmodeldataDir = lsst.utils.getPackageDir("fluxmodeldata")
+    dustmapsDir = lsst.utils.getPackageDir("dustmaps_cachedata")
+except LookupError:
+    fluxmodeldataDir = None
+    dustmapsDir = None
+
+
+@unittest.skipIf(
+    (fluxmodeldataDir is None) or (dustmapsDir is None),
+    "fluxmodeldata or dustmaps_cachedata not setup")
+class FitPfsFluxReferenceTestCase(lsst.utils.tests.TestCase):
+    def setUp(self):
+        try:
+            self.np_random = np.random.default_rng(0x981808a8fa8a744c)
+        except AttributeError:
+            self.np_random = np.random
+            self.np_random.seed(0xf6503311)
+
+        self.task = FitPfsFluxReferenceTask(config=FitPfsFluxReferenceConfig())
+        self.dustMap = DustMap()
+        self.extinctionCurve = F99ExtinctionCurve()
+        self.modelSet = FluxModelSet(fluxmodeldataDir)
+
+    def testRun(self):
+        """Test run() method
+        """
+        nFluxStd = 1
+        parameters, pfsConfig, pfsMerged = self.inventPfsMerged(
+            nFluxStd=nFluxStd, nFibers=10, nSamples=1000, snr=10, bbSnr=100
+        )
+        fluxReference = self.task.run(pfsConfig, pfsMerged)
+
+        self.assertEqual(len(fluxReference.fiberId), nFluxStd)
+
+    def inventPfsMerged(self, nFluxStd, nFibers, nSamples, snr, bbSnr):
+        """Invent a ``PfsMerged`` object.
+
+        Parameters
+        ----------
+        nFluxStd : `int`
+            Number of spectra whose targets are ``TargetType.FLUXSTD``.
+        nFibers : `int`
+            Number of total fibers.
+        nSamples : `int`
+            Number of sampling points along the wavelength axis.
+        snr : `float`
+            Signal to noise ratio for spectra. (variance = (flux / snr)**2).
+            This is used only for inventing ``pfsMerged.covar`` member.
+            This amount of noise won't be added to the flux.
+        bbSnr : `float`
+            Signal to noise ratio for broadband photometries.
+            This is used only for inventing ``pfsConfig.fluxErr`` member.
+            This amount of noise won't be added to the flux.
+
+        Returns
+        -------
+        parameters : `numpy.array`
+            Structured array indicating input parameters.
+        pfsConfig : `pfs.datamodel.pfsConfig.PfsConfig`
+            Configuration of the PFS top-end.
+        pfsMerged : `pfs.datamodel.pfsFiberArraySet.PfsFiberArraySet`
+            Observed spectra.
+        """
+        parameters = self.modelSet.parameters[
+            self.np_random.choice(len(self.modelSet.parameters), size=nFibers, replace=False)
+        ]
+
+        identity = Identity(visit=0, arm="r", spectrograph=1, pfsDesignId=0)
+        fiberId = np.arange(1, nFibers + 1, dtype=np.int32)
+        radecs = self.getRandomLonLat(size=nFibers)
+        ebvs = self.dustMap(radecs[:, 0], radecs[:, 1])
+
+        wavelength = np.empty(shape=(nFibers, nSamples), dtype=float)
+        wavelength[...] = np.linspace(400, 1200, num=nSamples, dtype=float).reshape(1, -1)
+        flux = np.empty(shape=wavelength.shape, dtype=float)
+
+        for i, (m, ebv) in enumerate(zip(parameters, ebvs)):
+            spectrum = self.modelSet.getSpectrum(
+                m["teff"], m["logg"], m["m"], m["alpha"],
+            )
+            spectrum.flux *= self.extinctionCurve.attenuation(spectrum.wavelength, ebv)
+            flux[i] = interpolateFlux(
+                spectrum.wavelength,
+                convolveLsf(spectrum.wavelength, spectrum.flux),
+                wavelength[i]
+            )
+
+        mask = np.zeros(shape=wavelength.shape, dtype=int)
+        sky = np.zeros(shape=wavelength.shape, dtype=float)
+        norm = np.ones(shape=wavelength.shape, dtype=float)
+
+        covar = np.zeros(shape=(len(fiberId), 3, wavelength.shape[-1]), dtype=float)
+        covar[:, 0, :] = np.square(flux / snr)
+
+        flags = MaskHelper()
+        metadata = {}
+
+        mask |= np.where(
+            np.isfinite(flux) & (flux > 0),
+            0,
+            flags.add("BAD"),
+        )
+        pfsMerged = PfsFiberArraySet(
+            identity, fiberId, wavelength, flux, mask, sky, norm, covar, flags, metadata
+        )
+        pfsConfig = self.inventPfsConfig(pfsMerged, radecs[:, 0], radecs[:, 1], nFluxStd, bbSnr)
+
+        return parameters, pfsConfig, pfsMerged
+
+    def inventPfsConfig(self, pfsMerged, ra, dec, nFluxStd, bbSnr):
+        """Invent a ``PfsConfig`` object.
+
+        Parameters
+        ----------
+        pfsMerged : `pfs.datamodel.pfsFiberArraySet.PfsFiberArraySet`
+            Observed spectra. Broadband fluxes will be computed from these spectra.
+        ra : `numpy.array` of `float`
+            R.A. in degrees.
+        dec : `numpy.array` of `float`
+            Dec. in degrees.
+        nFluxStd : `int`
+            Number of spectra whose targets are ``TargetType.FLUXSTD``.
+        bbSnr : `float`
+            Signal to noise ratio for broadband photometries.
+            This is used only for inventing ``pfsConfig.fluxErr`` member.
+            This amount of noise won't be added to the flux.
+
+        Returns
+        -------
+        pfsConfig : `pfs.datamodel.pfsConfig.PfsConfig`
+            Configuration of the PFS top-end.
+        """
+        bbFilters = ["g", "r2", "i2", "z", "y"]
+
+        fiberId = pfsMerged.fiberId
+        flux = np.empty(shape=(len(fiberId), len(bbFilters)), dtype=float)
+        for j, filter in enumerate(bbFilters):
+            curve = FilterCurve(filter)
+            for i in range(len(fiberId)):
+                # We cannot use pfsMerged.extractFiber()
+                # because it requires pfsConfig.
+                spectrum = makePfsSimpleSpectrum(pfsMerged.wavelength[i], pfsMerged.flux[i])
+                flux[i, j] = curve.photometer(spectrum)
+
+        fluxErr = flux / bbSnr
+
+        pfsDesignId = 0
+        visit0 = 0
+        raBoresight = 0.0
+        decBoresight = 0.0
+        posAng = 0.0
+        arms = "brn"
+        tract = np.full(fiberId.shape, 0, dtype=np.int32)
+        patch = np.full(fiberId.shape, "0,0", dtype="U8")
+        catId = np.full(fiberId.shape, 0, dtype=np.int32)
+        objId = np.arange(100, 100+len(fiberId), dtype=np.int64)
+
+        targetType = np.full(fiberId.shape, TargetType.SCIENCE, dtype=int)
+        targetType[self.np_random.choice(len(targetType), nFluxStd, replace=False)] = TargetType.FLUXSTD
+
+        fiberStatus = np.full(fiberId.shape, FiberStatus.GOOD, dtype=int)
+
+        fiberFlux = np.copy(flux)
+        psfFlux = np.copy(flux)
+        totalFlux = np.copy(flux)
+
+        fiberFluxErr = np.copy(fluxErr)
+        psfFluxErr = np.copy(fluxErr)
+        totalFluxErr = np.copy(fluxErr)
+
+        filterNames = [list(bbFilters) for i in range(len(fiberId))]
+        pfiCenter = np.full(fiberId.shape + (2,), 0.0, dtype=float)
+        pfiNominal = np.full(fiberId.shape + (2,), 0.0, dtype=float)
+        guideStars = None
+
+        return PfsConfig(
+            pfsDesignId,
+            visit0,
+            raBoresight,
+            decBoresight,
+            posAng,
+            arms,
+            fiberId,
+            tract,
+            patch,
+            ra,
+            dec,
+            catId,
+            objId,
+            targetType,
+            fiberStatus,
+            fiberFlux,
+            psfFlux,
+            totalFlux,
+            fiberFluxErr,
+            psfFluxErr,
+            totalFluxErr,
+            filterNames,
+            pfiCenter,
+            pfiNominal,
+            guideStars,
+        )
+
+    def getRandomLonLat(self, size=()):
+        """Get random points uniformly distributed
+        in the surface of the unit sphere.
+
+        Parameters
+        ----------
+        size : `int` or `tuple` of `int`
+            Number of points to get.
+
+        Returns
+        -------
+        lonlat : `numpy.array` of `float`
+            Longitudes and latitudes (in degrees) of the random points.
+            The shape of this array will be `size` + (2,).
+        """
+        if not hasattr(size, "__iter__"):
+            size = (size,)
+
+        xyz = np.empty(shape=size + (3,), dtype=float).reshape(-1, 3)
+        n = len(xyz)
+        while n > 0:
+            chunk = self.np_random.uniform(-1, 1, size=(2*n, 3))
+            r = np.hypot(chunk[:, 0], np.hypot(chunk[:, 1], chunk[:, 2]))
+            chunk = chunk[(0.5 < r) & (r < 1.0)]
+            chunk = chunk[:n]
+            xyz[(len(xyz) - n):(len(xyz) - n + len(chunk))] = chunk
+            n -= len(chunk)
+
+        lonlat = np.empty(shape=(len(xyz), 2), dtype=float).reshape(-1, 2)
+        lonlat[:, 0] = np.arctan2(xyz[:, 1], xyz[:, 0])
+        lonlat[:, 1] = np.arctan2(xyz[:, 2], np.hypot(xyz[:, 1], xyz[:, 0]))
+        return np.degrees(lonlat).reshape(size + (2,))
+
+
+def convolveLsf(wavelength, flux):
+    """Convolve a typical LSF to ``flux``
+
+    Parameters
+    ----------
+    wavelength : `numpy.array` of `float`
+        Wavelength in nm.
+    flux : `numpy.array` of `float`
+        Flux.
+
+    Returns
+    -------
+    convolvedFlux : `numpy.array` of `float`
+        Flux with the typical LSF convolved to it.
+    """
+    fwhm = 0.2  # typical FWHM, in nm, of LSF.
+    n = len(wavelength)
+    dlambda = wavelength[n//2 + 1] - wavelength[n//2]
+    sigma = fwhmToSigma(fwhm)
+    return GaussianKernel1D(width=sigma / dlambda).convolve(flux)
+
+
+def makePfsSimpleSpectrum(wavelength, flux):
+    """Make a ``PfsSimpleSpectrum`` object.
+
+    Parameters
+    ----------
+    wavelength : `numpy.array` of `float`
+        Wavelength in nm.
+    flux : `numpy.array` of `float`
+        Flux.
+
+    Returns
+    -------
+    pfsSimpleSpectrum : `pfs.datamodel.pfsSimpleSpectrum.PfsSimpleSpectrum`
+        Constructed ``PfsSimpleSpectrum`` object.
+    """
+    target = Target(0, 0, "0,0", 0)
+    mask = np.zeros(shape=wavelength.shape, dtype=int)
+    flags = MaskHelper()
+    return PfsSimpleSpectrum(target, wavelength, flux, mask, flags)
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    runTests(globals())

--- a/ups/drp_stella.table
+++ b/ups/drp_stella.table
@@ -8,6 +8,7 @@ setupRequired(datamodel)
 setupRequired(sconsUtils)
 setupRequired(pybind11)
 setupRequired(ip_isr)
+setupOptional(dustmaps_cachedata)
 setupOptional(fluxmodeldata)
 
 envPrepend(PATH, ${PRODUCT_DIR}/bin)


### PR DESCRIPTION
fitPfsFluxReference now considers Galactic extinction. `DustMap` and `F99ExtinctionCurve` classes are also introduced by this branch. No scientific quality is tested in the unit test of fitPfsFluxReference, for its output is too bad to pass any tests (PIPE2D-1012)