### PR TITLE
PIPE2D-1053: makeFluxModelInterpolator.py: Changes for full fluxmodeldata package

### DIFF
--- a/python/pfs/drp/stella/makeFluxModelInterpolator.py
+++ b/python/pfs/drp/stella/makeFluxModelInterpolator.py
@@ -6,6 +6,7 @@ import numpy as np
 from scipy.interpolate import RBFInterpolator
 
 import argparse
+import json
 import os
 import pickle
 import textwrap
@@ -22,7 +23,13 @@ def makeFluxModelInterpolator(fluxmodeldataPath):
         Number of processes.
     """
     modelSet = FluxModelSet(fluxmodeldataPath)
-    inputParameters = modelSet.parameters
+
+    if "isinterpolated" in modelSet.parameters.dtype.names:
+        inputParameters = modelSet.parameters[modelSet.parameters["isinterpolated"] == 0]
+    else:
+        inputParameters = modelSet.parameters
+
+    inputParameters.sort(order=["teff", "logg", "m", "alpha"])
 
     # make an empty array for input fluxes
     param = inputParameters[0]
@@ -35,15 +42,29 @@ def makeFluxModelInterpolator(fluxmodeldataPath):
         spectrum = modelSet.getSpectrum(param["teff"], param["logg"], param["m"], param["alpha"])
         fluxList[i, :] = spectrum.flux
 
-    # Best hyperparams found by means of cross-validation
-    kernel = "multiquadric"
-    teffScale = 0.0005
-    loggScale = 0.5
-    mScale = 2.0
-    alphaScale = 0.5
-    epsilon = 2.0
+    path = os.path.join(fluxmodeldataPath, "interpolator-hyperparams.json")
+    if os.path.exists(path):
+        with open(path, "r") as f:
+            hyperparams = json.load(f)
+        kernel = hyperparams["kernel"]
+        teffScale = hyperparams["teffScale"]
+        loggScale = hyperparams["loggScale"]
+        mScale = hyperparams["mScale"]
+        alphaScale = hyperparams["alphaScale"]
+        epsilon = hyperparams["epsilon"]
+        fluxScale = hyperparams["fluxScale"]
+    else:
+        print('Hyperparameter file not found. (Maybe a "small" fluxmodeldata package is set up)')
+        print("Default hyperparameters will be used.")
+        # Default hyperparams found by means of cross-validation
+        kernel = "multiquadric"
+        teffScale = 0.0005
+        loggScale = 0.5
+        mScale = 2.0
+        alphaScale = 0.5
+        epsilon = 2.0
+        fluxScale = np.nanmedian(fluxList)
 
-    fluxScale = np.nanmedian(fluxList)
     fluxList *= 1.0 / fluxScale
 
     xList = np.empty(shape=(len(inputParameters), 4), dtype=float)


### PR DESCRIPTION
The full fluxmodeldata package consists of the spectra in the small package, and of many pre-interpolated spectra. To make the interpolator from the full package, `makeFluxModelInterpolator.py` must choose only those spectra that are in the small package, which are not the product of the pre-interpolation. And `makeFluxModelInterpolator.py` must use the same hyperparameters as used in the pre-interpolation.

I don't recommend to set up the full fluxmodeldata package during developments because `scons tests` will come to take a few hours.