### PR TITLE
PIPE2D-1056: fitPfsFluxReference.py: explicitly shorten integer type to avoid exceptions

### DIFF
--- a/python/pfs/drp/stella/fitPfsFluxReference.py
+++ b/python/pfs/drp/stella/fitPfsFluxReference.py
@@ -736,7 +736,7 @@ class FitPfsFluxReferenceTask(CmdLineTask):
                 (low < wavelength) & (wavelength < high),
                 badMask,
                 0
-            )
+            ).astype(spectra.mask.dtype)
 
         # Mask edge regions.
         spectra.mask[...] |= np.where(
@@ -744,7 +744,7 @@ class FitPfsFluxReferenceTask(CmdLineTask):
             (spectra.wavelength < self.config.maxWavelength),
             0,
             spectra.flags.add("EDGE")
-        )
+        ).astype(spectra.mask.dtype)
 
         return spectra
 

--- a/tests/test_fitPfsFluxReference.py
+++ b/tests/test_fitPfsFluxReference.py
@@ -110,7 +110,7 @@ class FitPfsFluxReferenceTestCase(lsst.utils.tests.TestCase):
             flux[i] = interpolateFlux(spectrum.wavelength, convolvedFlux, wavelength[i])
             pfsMergedLsf[fiberId[i]] = warpLsf(lsf, spectrum.wavelength, wavelength[i])
 
-        mask = np.zeros(shape=wavelength.shape, dtype=int)
+        mask = np.zeros(shape=wavelength.shape, dtype=np.uint32)
         sky = np.zeros(shape=wavelength.shape, dtype=float)
         norm = np.ones(shape=wavelength.shape, dtype=float)
 
@@ -124,7 +124,8 @@ class FitPfsFluxReferenceTestCase(lsst.utils.tests.TestCase):
             np.isfinite(flux) & (flux > 0),
             0,
             flags.add("BAD"),
-        )
+        ).astype(mask.dtype)
+
         pfsMerged = PfsFiberArraySet(
             identity, fiberId, wavelength, flux, mask, sky, norm, covar, flags, metadata
         )
@@ -303,7 +304,7 @@ def makePfsSimpleSpectrum(wavelength, flux):
         Constructed ``PfsSimpleSpectrum`` object.
     """
     target = Target(0, 0, "0,0", 0)
-    mask = np.zeros(shape=wavelength.shape, dtype=int)
+    mask = np.zeros(shape=wavelength.shape, dtype=np.uint32)
     flags = MaskHelper()
     return PfsSimpleSpectrum(target, wavelength, flux, mask, flags)
 


### PR DESCRIPTION
The mask array of a PfsMerged object read from a file is of uint32 type, and longer integers sometimes have to be shortened when operating on the mask array. Because numpy won't implicitly shorten integers by default, we must cast the integers to uint32 explicitly.