### PR TITLE
PIPE2D-1113: fitPfsFluxReference: Add debug outputs

### DIFF
--- a/python/pfs/drp/stella/fitFluxCal.py
+++ b/python/pfs/drp/stella/fitFluxCal.py
@@ -4,6 +4,7 @@ import math
 from astropy import constants as const
 import numpy as np
 
+import lsstDebug
 from lsst.pex.config import Config, Field, ConfigurableField
 from lsst.pipe.base import CmdLineTask, ArgumentParser, Struct
 
@@ -16,6 +17,7 @@ from .lsf import warpLsf
 from .subtractSky1d import subtractSky1d
 from .FluxTableTask import FluxTableTask
 from .utils import getPfsVersions
+from .utils import debugging
 
 __all__ = ("FitFluxCalConfig", "FitFluxCalTask")
 
@@ -40,6 +42,8 @@ class FitFluxCalTask(CmdLineTask):
         super().__init__(*args, **kwargs)
         self.makeSubtask("fitFocalPlane")
         self.makeSubtask("fluxTable")
+
+        self.debugInfo = lsstDebug.Info(__name__)
 
     @classmethod
     def _makeArgumentParser(cls):
@@ -163,6 +167,13 @@ class FitFluxCalTask(CmdLineTask):
         calibVectors.norm[...] = 1.0  # We're deliberately changing the normalisation
 
         # TODO: Smooth the flux calibration vectors.
+
+        if self.debugInfo.doWriteCalibVector:
+            debugging.writeExtraData(
+                f"fitFluxCal-output/calibVector-{pfsMerged.filename}.pickle",
+                fiberId=calibVectors.fiberId,
+                calibVector=calibVectors.flux,
+            )
 
         # Before the call to `fitFocalPlane`, we have to ensure
         # that all the bad flags in `config.mask` are contained in `flags`.

--- a/python/pfs/drp/stella/utils/debugging.py
+++ b/python/pfs/drp/stella/utils/debugging.py
@@ -1,0 +1,20 @@
+import os
+import pickle
+
+__all__ = ["writeExtraData"]
+
+
+def writeExtraData(path: str, **kwargs) -> None:
+    """Pickle extra data for debugging.
+
+    Parameters
+    ----------
+    path : `str`
+        Output file name. Its directory will be created if not exists.
+    **kwargs : `Dict[str, Any]`
+        Extra data to pickle.
+    """
+    dirname = os.path.dirname(path)
+    os.makedirs(dirname, exist_ok=True)
+    with open(path, "wb") as f:
+        pickle.dump(kwargs, f)


### PR DESCRIPTION
Among the requested debug products, `flux_scaling_chi2` is always put to the pfsFluxReference object because it can be useful to `fitFluxCal.py`. The other debug products are output to the current working directory when requested.