### PR TITLE
PIPE2D-1110: Change filter names

### DIFF
--- a/python/pfs/drp/stella/fitBroadbandSED.py
+++ b/python/pfs/drp/stella/fitBroadbandSED.py
@@ -17,8 +17,26 @@ class FitBroadbandSEDConfig(Config):
     filterMappings = DictField(
         keytype=str, itemtype=str,
         default={
-            "g": "HSCg", "r": "HSCr", "r2": "HSCr2", "i": "HSCi", "i2": "HSCi2",
-            "z": "HSCz", "y": "HSCy"
+            "g_hsc": "HSCg",
+            "r_old_hsc": "HSCr",
+            "r2_hsc": "HSCr2",
+            "i_old_hsc": "HSCi",
+            "i2_hsc": "HSCi2",
+            "z_hsc": "HSCz",
+            "y_hsc": "HSCy",
+            "g_ps1": "PS1g",
+            "r_ps1": "PS1r",
+            "i_ps1": "PS1i",
+            "z_ps1": "PS1z",
+            "y_ps1": "PS1y",
+            "bp_gaia": "GaiaBp",
+            "rp_gaia": "GaiaRp",
+            "g_gaia": "GaiaG",
+            "u_sdss": "SDSSu",
+            "g_sdss": "SDSSg",
+            "r_sdss": "SDSSr",
+            "i_sdss": "SDSSi",
+            "z_sdss": "SDSSz",
         },
         doc="Conversion table from pfsConfig's filter names to those used by `fluxLibrary`"
     )
@@ -96,7 +114,7 @@ class FitBroadbandSEDTask(Task):
         ----------
         filterNames : `list` of `str`
             List of filters used to measure the fiber fluxes for each filter.
-            e.g. ``["g", "i"]``.
+            e.g. ``["g_hsc", "i2_hsc"]``.
         fiberFlux : `list` of `float`
             Array of fiber fluxes for each fiber, in [nJy].
         fiberFluxErr : `list` of `float`

--- a/python/pfs/drp/stella/fitReference.py
+++ b/python/pfs/drp/stella/fitReference.py
@@ -109,26 +109,28 @@ class FilterCurve(TransmissionCurve):
         Name of the filter. Must be one that is known.
     """
     filenames = {
-        "g": "HSC/hsc_g_v2018.dat",
-        "r": "HSC/hsc_r_v2018.dat",
-        "r2": "HSC/hsc_r2_v2018.dat",
-        "i": "HSC/hsc_i_v2018.dat",
-        "i2": "HSC/hsc_i2_v2018.dat",
-        "z": "HSC/hsc_z_v2018.dat",
-        "y": "HSC/hsc_y_v2018.dat",
-        "PS1g": "PS1/PS1_g.dat",
-        "PS1r": "PS1/PS1_r.dat",
-        "PS1i": "PS1/PS1_i.dat",
-        "PS1z": "PS1/PS1_z.dat",
-        "PS1y": "PS1/PS1_y.dat",
-        "GaiaBp": "Gaia/Gaia_Bp.txt",
-        "GaiaRp": "Gaia/Gaia_Rp.txt",
-        "GaiaG": "Gaia/Gaia_G.txt",
-        "SDSSu": "SDSS/u_all_tel_atm13.dat",
-        "SDSSg": "SDSS/g_all_tel_atm13.dat",
-        "SDSSr": "SDSS/r_all_tel_atm13.dat",
-        "SDSSi": "SDSS/i_all_tel_atm13.dat",
-        "SDSSz": "SDSS/z_all_tel_atm13.dat",
+        "g_hsc": "HSC/hsc_g_v2018.dat",
+        # This is HSC-R (as opposed to HSC-R2)
+        "r_old_hsc": "HSC/hsc_r_v2018.dat",
+        "r2_hsc": "HSC/hsc_r2_v2018.dat",
+        # This is HSC-I (as opposed to HSC-I2)
+        "i_old_hsc": "HSC/hsc_i_v2018.dat",
+        "i2_hsc": "HSC/hsc_i2_v2018.dat",
+        "z_hsc": "HSC/hsc_z_v2018.dat",
+        "y_hsc": "HSC/hsc_y_v2018.dat",
+        "g_ps1": "PS1/PS1_g.dat",
+        "r_ps1": "PS1/PS1_r.dat",
+        "i_ps1": "PS1/PS1_i.dat",
+        "z_ps1": "PS1/PS1_z.dat",
+        "y_ps1": "PS1/PS1_y.dat",
+        "bp_gaia": "Gaia/Gaia_Bp.txt",
+        "rp_gaia": "Gaia/Gaia_Rp.txt",
+        "g_gaia": "Gaia/Gaia_G.txt",
+        "u_sdss": "SDSS/u_all_tel_atm13.dat",
+        "g_sdss": "SDSS/g_all_tel_atm13.dat",
+        "r_sdss": "SDSS/r_all_tel_atm13.dat",
+        "i_sdss": "SDSS/i_all_tel_atm13.dat",
+        "z_sdss": "SDSS/z_all_tel_atm13.dat",
     }
     """Mapping of filter name to filename"""
 

--- a/tests/test_fitBroadbandSED.py
+++ b/tests/test_fitBroadbandSED.py
@@ -24,7 +24,7 @@ class FitBroadbandSEDTestCase(lsst.utils.tests.TestCase):
         """Test run() method
         """
         random = numpy.random.RandomState(0xfeed5eed)
-        filters = ["g", "r", "i", "z", "y"]
+        filters = ["g_hsc", "r2_hsc", "i2_hsc", "z_hsc", "y_hsc"]
         filters = [self.fitBroadbandSED.config.filterMappings.get(f, f) for f in filters]
 
         trueSEDIndices = numpy.arange(len(self.fitBroadbandSED.fluxLibrary))[::5]

--- a/tests/test_fitPfsFluxReference.py
+++ b/tests/test_fitPfsFluxReference.py
@@ -156,7 +156,7 @@ class FitPfsFluxReferenceTestCase(lsst.utils.tests.TestCase):
         pfsConfig : `pfs.datamodel.pfsConfig.PfsConfig`
             Configuration of the PFS top-end.
         """
-        bbFilters = ["g", "r2", "i2", "z", "y"]
+        bbFilters = ["g_hsc", "r2_hsc", "i2_hsc", "z_hsc", "y_hsc"]
 
         fiberId = pfsMerged.fiberId
         flux = np.empty(shape=(len(fiberId), len(bbFilters)), dtype=float)


### PR DESCRIPTION
The integration test and the weekly test will be broken after this change. To fix this problem, run
`PIPE2D-1110-change-filter-names.py`.
There is a link to this file in PIPE2D-1110, JIRA.