### PR TITLE
PIPE2D-1147: estimateRadialVelocity: Change `findMethod` to "quadratic"

### DIFF
--- a/python/pfs/drp/stella/estimateRadialVelocity.py
+++ b/python/pfs/drp/stella/estimateRadialVelocity.py
@@ -9,6 +9,72 @@ import scipy.optimize
 
 import math
 
+from typing import Sequence
+from typing import Any
+
+try:
+    from numpy.typing import NDArray
+except ImportError:
+    NDArray = Sequence
+
+
+__all__ = ["EstimateRadialVelocityConfig", "EstimateRadialVelocityTask"]
+
+
+class CrossCorrelationFunction:
+    r"""Cross correlation function:
+    ccf[k] = \sum_{i} flux[i] model(\lambda[i] * scale[k]).
+
+    Parameters
+    ----------
+    flux : `np.ndarray` of `float`
+        Shape ``(numWavelength,)``. The array ``flux`` in the equation above.
+    variance : `np.ndarray` of `float`
+        Shape ``(numWavelength,)``. Variance of ``flux``.
+    scaledModel : `np.ndarray` of `float`
+        Shape ``(numVelocities, numWavelength)``.
+        The matrix ``model(\lambda[i] * scale[k])`` in the equation above.
+        The first index is ``k``, and the second index is ``i``.
+    """
+
+    ccf: NDArray[np.float64]
+    """Shape ``(numVelocities,)``. Cross correlation function.
+    """
+
+    def __init__(
+        self, flux: NDArray[np.float64], variance: NDArray[np.float64], scaledModel: NDArray[np.float64]
+    ) -> None:
+        self.__variance = variance
+        self.__scaledModel = scaledModel
+        self.ccf = scaledModel @ flux
+
+    def getCovar(self, slice: Any, amplifier: float = 1) -> NDArray[np.float64]:
+        """Get the covariance matrix of ``self.ccf``.
+
+        Parameters
+        ----------
+        slice : `Any`
+            Slice to thin out ``self.ccf``.
+            It is a boolean array of length ``numVelocities``, for example.
+            Pass ``Ellipsis`` to get the entire covariance matrix.
+        amplifier : `float`
+            A constant by which to multiply all elements of the covariance.
+            The multiplication is executed most efficiently.
+
+        Returns
+        -------
+        covar : `np.ndarray` of `float`
+            Covariance matrix of ``ccf[slice]``
+        """
+        variance = self.__variance
+        scaledModel = self.__scaledModel[slice, :]
+        if amplifier == 1:
+            return (scaledModel * variance.reshape(1, -1)) @ np.transpose(scaledModel)
+        elif len(variance) < len(scaledModel) ** 2:
+            return (scaledModel * (amplifier * variance.reshape(1, -1))) @ np.transpose(scaledModel)
+        else:
+            return amplifier * ((scaledModel * variance.reshape(1, -1)) @ np.transpose(scaledModel))
+
 
 class EstimateRadialVelocityConfig(Config):
     """Configuration for EstimateRadialVelocityTask"""
@@ -19,8 +85,9 @@ class EstimateRadialVelocityConfig(Config):
         allowed={
             "peak": "The sampled point at which the cross-correlation is maximum.",
             "gauss": "Peak of a Gaussian fit to the cross-correlation.",
+            "quadratic": "Peak of the quadratic interpolation around the argmax of the cross-correlation.",
         },
-        default="gauss",
+        default="quadratic",
         optional=False,
     )
 
@@ -32,7 +99,7 @@ class EstimateRadialVelocityConfig(Config):
         doc="Step of searched range of radial velocity, in km/s."
         " The actual step may be slightly smaller than this value.",
         dtype=float,
-        default=5.0,
+        default=10,
     )
 
     peakRange = Field(
@@ -42,8 +109,9 @@ class EstimateRadialVelocityConfig(Config):
     )
 
     useCovar = Field(
-        doc="Whether to use covariance. If False, use variance only."
-        " Covariance used, the returned error bar will be more correct,"
+        doc='Whether to use covariance.  (valid when `findMethod` = "gauss")'
+        " If False, use variance only."
+        " If covariance is used, the returned error bar will be more correct,"
         " but this task will be far less robust.",
         dtype=bool,
         default=True,
@@ -82,8 +150,6 @@ class EstimateRadialVelocityTask(Task):
             Radial velocity in km/s.
         error : `float`
             Standard deviation of ``velocity``.
-            This is reliable only if ``config.findMethod="gauss"``
-            and ``config.useCovar=True``.
         fail : `bool`
             True if measuring ``velocity`` failed.
         crossCorr : `numpy.array`
@@ -128,52 +194,201 @@ class EstimateRadialVelocityTask(Task):
         scaledModel /= doppler.reshape(-1, 1)
 
         # This is cross correlation function
-        ccf = scaledModel @ flux
+        ccf = CrossCorrelationFunction(flux, variance, scaledModel)
 
         # c.c.f. is returned to the caller in this format for debugging.
-        crossCorr = np.empty(len(ccf), dtype=[("velocity", float), ("crosscorr", float)])
+        crossCorr = np.empty(len(ccf.ccf), dtype=[("velocity", float), ("crosscorr", float)])
         crossCorr["velocity"] = searchVelocity
-        crossCorr["crosscorr"] = ccf
+        crossCorr["crosscorr"] = ccf.ccf
 
         # Find the peak of CCF
+        retvalue = self.findPeak(searchVelocity, ccf)
+        retvalue.crossCorr = crossCorr
+        return retvalue
+
+    def findPeak(self, searchVelocity: NDArray[np.float64], ccf: CrossCorrelationFunction) -> Struct:
+        """Find the peak of ``ccf``.
+
+        Parameters
+        ----------
+        searchVelocity : `np.ndarray` of `float`
+            Shape ``(numVelocities)``. Velocity in km/s.
+            This is x-axis of ``ccf``.
+        ccf : `CrossCorrelationFunction`
+            Cross correlation function.
+
+        Returns
+        -------
+        velocity : `float`
+            Radial velocity in km/s.
+        error : `float`
+            Standard deviation of ``velocity``.
+        fail : `bool`
+            True if measuring ``velocity`` failed.
+        """
         if self.config.findMethod == "peak":
-            iMax = np.argmax(ccf)
-            velocity = searchVelocity[iMax]
-            fail = iMax == 0 or iMax + 1 == len(ccf)
-            # We have to think of the error...
-            return Struct(velocity=velocity, error=np.nan, fail=fail, crossCorr=crossCorr)
+            return findPeakNaive(searchVelocity, ccf, self.config)
+        elif self.config.findMethod == "quadratic":
+            return findPeakQuadratic(searchVelocity, ccf, self.config)
+        elif self.config.findMethod == "gauss":
+            return findPeakGauss(searchVelocity, ccf, self.config)
+        else:
+            raise RuntimeError(f"config.findMethod has a wrong value: '{self.config.findMethod}'.")
 
-        # Gaussian fit
-        if self.config.findMethod == "gauss":
 
-            def gauss(v, a, v_est, sigma):
-                return a * np.exp((v - v_est) ** 2 / (-2 * sigma**2))
+def findPeakNaive(
+    searchVelocity: NDArray[np.float64], ccf: CrossCorrelationFunction, config: Config
+) -> Struct:
+    """Find the peak of ``ccf`` naively.
 
-            iMax = np.argmax(ccf)
-            velocity = searchVelocity[iMax]
-            fail = iMax == 0 or iMax + 1 == len(ccf)
-            if fail:
-                return Struct(velocity=velocity, error=np.nan, fail=fail, crossCorr=crossCorr)
+    Parameters
+    ----------
+    searchVelocity : `np.ndarray` of `float`
+        Shape ``(numVelocities)``. Velocity in km/s.
+        This is x-axis of ``ccf``.
+    ccf : `CrossCorrelationFunction`
+        Cross correlation function.
+    config : `Config`
+        Not used.
 
-            coeff = 1.0 / ccf[iMax]
-            fitIndex = (searchVelocity > (velocity - self.config.peakRange / 2)) & (
-                searchVelocity < (velocity + self.config.peakRange / 2)
-            )
-            fitVelocity = searchVelocity[fitIndex]
-            fitCcf = coeff * ccf[fitIndex]
-            scaledModel = scaledModel[fitIndex, :]
-            fitCovar = (scaledModel * (coeff * coeff * variance.reshape(1, -1))) @ np.transpose(scaledModel)
+    Returns
+    -------
+    velocity : `float`
+        Radial velocity in km/s.
+    error : `float`
+        Standard deviation of ``velocity``.
+        This is always ``nan``.
+    fail : `bool`
+        True if measuring ``velocity`` failed.
+    """
+    iMax = np.argmax(ccf.ccf)
+    velocity = searchVelocity[iMax]
+    fail = iMax == 0 or iMax + 1 == len(ccf.ccf)
+    return Struct(velocity=velocity, error=np.nan, fail=fail)
 
-            if not self.config.useCovar:
-                # `scipy.optimize.curve_fit()` takes standard deviation
-                # rather than variance if `sigma` argument is not a matrix.
-                fitCovar = np.sqrt(np.diag(fitCovar))
 
-            iniParam = [1.0, velocity, self.config.peakRange]
-            pfit, pcov = scipy.optimize.curve_fit(
-                gauss, fitVelocity, fitCcf, sigma=fitCovar, p0=iniParam, absolute_sigma=True
-            )
+def findPeakQuadratic(
+    searchVelocity: NDArray[np.float64], ccf: CrossCorrelationFunction, config: Config
+) -> Struct:
+    """Find the peak of ``ccf`` with quadratic interpolation.
 
-            return Struct(velocity=pfit[1], error=np.sqrt(pcov[1][1]), fail=fail, crossCorr=crossCorr)
+    Parameters
+    ----------
+    searchVelocity : `np.ndarray` of `float`
+        Shape ``(numVelocities)``. Velocity in km/s.
+        This is x-axis of ``ccf``.
+    ccf : `CrossCorrelationFunction`
+        Cross correlation function.
+    config : `Config`
+        Not used.
 
-        raise RuntimeError("config.findMethod has a wrong value.")
+    Returns
+    -------
+    velocity : `float`
+        Radial velocity in km/s.
+    error : `float`
+        Standard deviation of ``velocity``.
+    fail : `bool`
+        True if measuring ``velocity`` failed.
+    """
+    iMax = np.argmax(ccf.ccf)
+    velocity = searchVelocity[iMax]
+    fail = iMax == 0 or iMax + 1 == len(ccf.ccf)
+    if fail:
+        return Struct(velocity=velocity, error=np.nan, fail=fail)
+
+    velocityL = searchVelocity[iMax - 1]
+    velocityR = searchVelocity[iMax + 1]
+    ccfL = ccf.ccf[iMax - 1]
+    ccf0 = ccf.ccf[iMax]
+    ccfR = ccf.ccf[iMax + 1]
+
+    # Find f(v) = a*v**2 + b*v + c
+    # such that ccfL = f(velocityL), ccf0 = f(velocity),
+    # and ccfR = f(velocityR).
+    m00 = velocityL**2 - velocity**2
+    m01 = velocityL - velocity
+    m10 = velocityR**2 - velocity**2
+    m11 = velocityR - velocity
+    x0 = ccfL - ccf0
+    x1 = ccfR - ccf0
+    det = m00 * m11 - m01 * m10
+    a = (m11 * x0 - m01 * x1) / det
+    b = (m00 * x1 - m10 * x0) / det
+
+    # Peak position of f(v) = a*v**2 + b*v + c
+    rv = -b / (2 * a)
+
+    # \frac{\partial rv}{\partial ccf_i}
+    # where ccf_0 = ccfL, ccf_1 = ccf0, ccf_2 = ccfR.
+    drv_over_dccf = np.empty(shape=(3, 1), dtype=float)
+    drv_over_dccf[0, 0] = (m10 * a + m11 * b) / (2 * det * a**2)
+    drv_over_dccf[2, 0] = -(m00 * a + m01 * b) / (2 * det * a**2)
+    drv_over_dccf[1, 0] = -drv_over_dccf[0, 0] - drv_over_dccf[2, 0]
+
+    peakIndex = np.arange(iMax - 1, iMax + 2)
+    covarCcf = ccf.getCovar(peakIndex)
+    varRv = np.transpose(drv_over_dccf) @ covarCcf @ drv_over_dccf
+
+    return Struct(velocity=rv, error=math.sqrt(varRv[0, 0]), fail=fail)
+
+
+def findPeakGauss(
+    searchVelocity: NDArray[np.float64], ccf: CrossCorrelationFunction, config: Config
+) -> Struct:
+    """Find the peak of ``ccf`` with Gaussian fit.
+
+    Parameters
+    ----------
+    searchVelocity : `np.ndarray` of `float`
+        Shape ``(numVelocities)``. Velocity in km/s.
+        This is x-axis of ``ccf``.
+    ccf : `CrossCorrelationFunction`
+        Cross correlation function.
+    config : `Config`
+        This must contain the following members:
+
+        peakRange : `float`
+            Velocity range, in km/s, used in fitting Gaussian.
+        useCovar : `bool`
+            Whether to use covariance.
+
+    Returns
+    -------
+    velocity : `float`
+        Radial velocity in km/s.
+    error : `float`
+        Standard deviation of ``velocity``.
+        This is correct only if ``config.useCovar=True``.
+    fail : `bool`
+        True if measuring ``velocity`` failed.
+    """
+
+    def gauss(v, a, v_est, sigma):
+        return a * np.exp((v - v_est) ** 2 / (-2 * sigma**2))
+
+    iMax = np.argmax(ccf.ccf)
+    velocity = searchVelocity[iMax]
+    fail = iMax == 0 or iMax + 1 == len(ccf.ccf)
+    if fail:
+        return Struct(velocity=velocity, error=np.nan, fail=fail)
+
+    coeff = 1.0 / ccf.ccf[iMax]
+    fitIndex = (searchVelocity > (velocity - config.peakRange / 2)) & (
+        searchVelocity < (velocity + config.peakRange / 2)
+    )
+    fitVelocity = searchVelocity[fitIndex]
+    fitCcf = coeff * ccf.ccf[fitIndex]
+    fitCovar = ccf.getCovar(fitIndex, amplifier=coeff * coeff)
+
+    if not config.useCovar:
+        # `scipy.optimize.curve_fit()` takes standard deviation
+        # rather than variance if `sigma` argument is not a matrix.
+        fitCovar = np.sqrt(np.diag(fitCovar))
+
+    iniParam = [1.0, velocity, config.peakRange]
+    pfit, pcov = scipy.optimize.curve_fit(
+        gauss, fitVelocity, fitCcf, sigma=fitCovar, p0=iniParam, absolute_sigma=True
+    )
+
+    return Struct(velocity=pfit[1], error=np.sqrt(pcov[1][1]), fail=fail)

--- a/python/pfs/drp/stella/fitPfsFluxReference.py
+++ b/python/pfs/drp/stella/fitPfsFluxReference.py
@@ -283,7 +283,7 @@ class FitPfsFluxReferenceTask(CmdLineTask):
 
         flag = self.fitFlagNames.add("ESTIMATERADIALVELOCITY_FAILED")
         for fiberId, velocity in zip(pfsConfig.fiberId, radialVelocities):
-            if velocity is None or not np.isfinite(velocity.velocity):
+            if velocity is None or velocity.fail or not np.isfinite(velocity.velocity):
                 fitFlag[fiberId] = flag
 
         # Likelihoods from spectral fitting, where line spectra matter.
@@ -404,8 +404,9 @@ class FitPfsFluxReferenceTask(CmdLineTask):
         -------
         radialVelocities : `List[Optional[lsst.pipe.base.Struct]]`
             Radial velocity for each fiber.
-            Each element, if not None, has ``velocity``, ``error``, and
-            ``crossCorr`` as its member. See ``EstimateRadialVelocityTask``.
+            Each element, if not None, has ``velocity``, ``error``,
+            ``crossCorr``, and ``fail`` as its member.
+            See ``EstimateRadialVelocityTask``.
         """
         # Find the best model from broad bands.
         # This model is used as the reference for cross-correlation calculation
@@ -507,7 +508,7 @@ class FitPfsFluxReferenceTask(CmdLineTask):
             Combined line-spread functions indexed by fiberId.
         radialVelocities : `list` of `Optional[lsst.pipe.base.Struct]`
             Radial velocity for each fiber.
-            Each element, if not None, has `velocity` and `error`
+            Each element, if not None, has ``velocity``, ``error``, and ``fail``
             as its member. See ``EstimateRadialVelocityTask``.
         priorPdfs : `list` of `numpy.array` of `float`
             For each ``priorPdfs[iSpectrum]`` in ``priorPdfs``,
@@ -558,7 +559,7 @@ class FitPfsFluxReferenceTask(CmdLineTask):
             for iFiber, (obsSpectrum, velocity, prior) in enumerate(
                 zip(fibers(pfsConfig, obsSpectra), radialVelocities, priorPdf)
             ):
-                if velocity is None or not np.isfinite(velocity.velocity):
+                if velocity is None or velocity.fail or not np.isfinite(velocity.velocity):
                     continue
                 if not (prior > 1e-8):
                     continue

--- a/tests/test_estimateRadialVelocity.py
+++ b/tests/test_estimateRadialVelocity.py
@@ -40,6 +40,15 @@ class EstimateRadialVelocityTestCase(lsst.utils.tests.TestCase):
     that cannot be explained by the statistical error.
     """
 
+    varianceTolerance = 1.2
+    """Error estimate (`retvalue.error`) must satisfy `1 / varianceTolerance < ratio < varianceTolerance`,
+    where `ratio = (variance of retvalue.velocity) / (average of retvalue.error**2)`.
+    """
+
+    numTrials = 100
+    """Number of trials for acquisition of statistics
+    """
+
     def setUp(self):
         self.estimateRadialVelocity = EstimateRadialVelocityTask(config=EstimateRadialVelocityConfig())
         self.np_random = np.random.RandomState(seed=0x0123456)
@@ -56,12 +65,29 @@ class EstimateRadialVelocityTestCase(lsst.utils.tests.TestCase):
         trueVelocity : `float`
             Radial velocity of the fake observed spectrum, in km/s.
         """
-        obsSpectrum = self.createObsSpectrum(self.refSpectrum, trueVelocity, self.obsLsfSigma, snr)
-        with temporarilyRuinMaskedRegion(obsSpectrum):
-            with temporarilyRuinMaskedRegion(self.refSpectrum):
-                result = self.estimateRadialVelocity.run(obsSpectrum, self.refSpectrum)
+        sum_1 = 0
+        sum_x = 0
+        sum_xx = 0
+        sum_v = 0
+        for i in range(self.numTrials):
+            obsSpectrum = self.createObsSpectrum(self.refSpectrum, trueVelocity, self.obsLsfSigma, snr)
+            with temporarilyRuinMaskedRegion(obsSpectrum):
+                with temporarilyRuinMaskedRegion(self.refSpectrum):
+                    result = self.estimateRadialVelocity.run(obsSpectrum, self.refSpectrum)
+                    sum_1 += 1
+                    sum_x += result.velocity
+                    sum_xx += result.velocity**2
+                    sum_v += result.error**2
 
-        self.assertLess(abs(result.velocity - trueVelocity), self.permissibleError + 2*result.error)
+        average = sum_x / sum_1
+        variance = (sum_xx / sum_1 - average**2) * (sum_1 / (sum_1 - 1))
+        estimatedVar = sum_v / sum_1
+        varianceRatio = (estimatedVar + self.permissibleError**2) / variance
+        error = (estimatedVar + self.permissibleError**2) / np.sqrt(sum_1)
+
+        self.assertLess(abs(average - trueVelocity), 2*error)
+        self.assertGreater(varianceRatio, 1 / self.varianceTolerance)
+        self.assertLess(varianceRatio, self.varianceTolerance)
 
     def createMask(self, shape, density):
         """Create a fake mask array

--- a/tests/test_estimateRadialVelocity.py
+++ b/tests/test_estimateRadialVelocity.py
@@ -45,7 +45,7 @@ class EstimateRadialVelocityTestCase(lsst.utils.tests.TestCase):
         self.np_random = np.random.RandomState(seed=0x0123456)
         self.refSpectrum = self.createRefSpectrum(self.refLsfSigma)
 
-    @methodParameters(snr=[25, 50, 100, 200, 400], trueVelocity=[-200, -100, 0, 100, 200])
+    @methodParameters(snr=[10, 20, 30, 40, 50], trueVelocity=[-200, -100, 0, 100, 200])
     def test(self, snr, trueVelocity):
         """Test run()
 

--- a/tests/test_fitBroadbandSED.py
+++ b/tests/test_fitBroadbandSED.py
@@ -57,7 +57,7 @@ class FitBroadbandSEDTestCase(lsst.utils.tests.TestCase):
 
         pfsConfig = PfsConfig(
             pfsDesignId=1,
-            visit0=1,
+            visit=1,
             raBoresight=1.0,
             decBoresight=1.0,
             posAng=1.0,

--- a/tests/test_fitPfsFluxReference.py
+++ b/tests/test_fitPfsFluxReference.py
@@ -171,7 +171,7 @@ class FitPfsFluxReferenceTestCase(lsst.utils.tests.TestCase):
         fluxErr = flux / bbSnr
 
         pfsDesignId = 0
-        visit0 = 0
+        visit = 0
         raBoresight = 0.0
         decBoresight = 0.0
         posAng = 0.0
@@ -201,7 +201,7 @@ class FitPfsFluxReferenceTestCase(lsst.utils.tests.TestCase):
 
         return PfsConfig(
             pfsDesignId,
-            visit0,
+            visit,
             raBoresight,
             decBoresight,
             posAng,


### PR DESCRIPTION
Previously, we found the peak position of the cross correlation function
by fitting a Gaussian to the c.c.f. Because exceptions were sometimes
raised by the optimizer, we change the peak-finding method to quadratic
interpolation. Because radial velocities found by the latter method
have large variance when `searchStep` is small, we change it from 5 km/s
to 10 km/s (This step should not be wider than the smallest possible
LSF). In addition, we lower S/N used in the unit test according to
true observed spectra.