### PR TITLE
PIPE2D-1149: Make fitPfsFluxReference & fitFluxCal compatible with Gen3 butler

### DIFF
--- a/pipelines/science2.yaml
+++ b/pipelines/science2.yaml
@@ -1,0 +1,12 @@
+description: Full 2D-DRP science pipeline with fitPfsFluxReference and fitFluxCal.
+imports:
+  - $DRP_STELLA_DIR/pipelines/reduceExposure.yaml
+tasks:
+  fitPfsFluxReference:
+    class: pfs.drp.stella.fitPfsFluxReference.FitPfsFluxReferenceTask
+    config:
+      minBroadbandFluxes: 1
+  fitFluxCal:
+    class: pfs.drp.stella.fitFluxCal.FitFluxCalTask
+  coaddSpectra:
+    class: pfs.drp.stella.coaddSpectra.CoaddSpectraTask


### PR DESCRIPTION
Added the elements necessary for `FitPfsFluxReferenceTask` and `FitFluxCalTask` to be compatible with Gen3 butler.