### PR TITLE
PIPE2D-1159: Please always provide a detectorMap_used file

### DIFF
--- a/python/pfs/drp/stella/reduceExposure.py
+++ b/python/pfs/drp/stella/reduceExposure.py
@@ -535,8 +535,9 @@ class ReduceExposureTask(CmdLineTask):
                 history = f"reduceExposure on {date} with visit={sensorRef.dataId['visit']}"
                 detectorMap.metadata.add("HISTORY", history)
 
-                sensorRef.put(detectorMap, "detectorMap_used")
                 fiberTraces = fiberProfiles.makeFiberTracesFromDetectorMap(detectorMap)  # use new detectorMap
+
+        sensorRef.put(detectorMap, "detectorMap_used")
 
         if self.config.doMeasurePsf:
             psf = self.measurePsf.runSingle(exposure, detectorMap)


### PR DESCRIPTION
It's helpful to always have detectorMap_used available, regardless of the configuration used.