### PR TITLE
PIPE2D-1208: Make fitPfsFluxReference even faster

### DIFF
--- a/python/pfs/drp/stella/fitBroadbandSED.py
+++ b/python/pfs/drp/stella/fitBroadbandSED.py
@@ -2,7 +2,7 @@ from pfs.datamodel.pfsConfig import PfsConfig, TargetType
 
 import lsstDebug
 import lsst.daf.persistence
-from lsst.pex.config import Config, ChoiceField, DictField, Field
+from lsst.pex.config import Config, ChoiceField, Field
 from lsst.pipe.base import Task
 from lsst.utils import getPackageDir
 
@@ -35,34 +35,6 @@ class FitBroadbandSEDConfig(Config):
         },
         default="psf",
         optional=False,
-    )
-
-    filterMappings = DictField(
-        keytype=str,
-        itemtype=str,
-        default={
-            "g_hsc": "HSCg",
-            "r_old_hsc": "HSCr",
-            "r2_hsc": "HSCr2",
-            "i_old_hsc": "HSCi",
-            "i2_hsc": "HSCi2",
-            "z_hsc": "HSCz",
-            "y_hsc": "HSCy",
-            "g_ps1": "PS1g",
-            "r_ps1": "PS1r",
-            "i_ps1": "PS1i",
-            "z_ps1": "PS1z",
-            "y_ps1": "PS1y",
-            "bp_gaia": "GaiaBp",
-            "rp_gaia": "GaiaRp",
-            "g_gaia": "GaiaG",
-            "u_sdss": "SDSSu",
-            "g_sdss": "SDSSg",
-            "r_sdss": "SDSSr",
-            "i_sdss": "SDSSi",
-            "z_sdss": "SDSSz",
-        },
-        doc="Conversion table from pfsConfig's filter names to those used by `fluxLibrary`",
     )
 
     soften = Field(
@@ -197,8 +169,7 @@ class FitBroadbandSEDTask(Task):
         # Soften noises
         observedNoises = numpy.hypot(observedNoises[isgood], self.config.soften * observedFluxes)
 
-        # Convert filter names.
-        filterNames = [self.config.filterMappings.get(f, f) for f, good in zip(filterNames, isgood) if good]
+        filterNames = [f for f, good in zip(filterNames, isgood) if good]
 
         # Note: fluxLibrary.shape == (nSEDs, nBands)
         fluxLibrary = numpy.lib.recfunctions.structured_to_unstructured(

--- a/tests/test_fitBroadbandSED.py
+++ b/tests/test_fitBroadbandSED.py
@@ -25,7 +25,6 @@ class FitBroadbandSEDTestCase(lsst.utils.tests.TestCase):
         """
         random = numpy.random.RandomState(0xfeed5eed)
         filters = ["g_hsc", "r2_hsc", "i2_hsc", "z_hsc", "y_hsc"]
-        filters = [self.fitBroadbandSED.config.filterMappings.get(f, f) for f in filters]
 
         trueSEDIndices = numpy.arange(len(self.fitBroadbandSED.fluxLibrary))[::5]
         nFibers = len(trueSEDIndices)

--- a/tests/test_fluxModelSet.py
+++ b/tests/test_fluxModelSet.py
@@ -30,6 +30,10 @@ class FluxModelSetTestCase(lsst.utils.tests.TestCase):
         self.assertIsInstance(spectrum.wavelength, WavelengthArray)
 
 
+class TestMemory(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
 def setup_module(module):
     lsst.utils.tests.init()
 


### PR DESCRIPTION
This pull request contains three main changes:
1. Pack model templates into one uncompressed zip file.
2. Downsample model templates before continuum fitting.
With these two changes, fitPfsFluxReference in the integration test will run in less than 1 hour/visit/core with "full" model set.

3. Remove the filter name conversion table from FitBroadbandSEDTask.
This change will make the class simpler, though it will break compatibility to old fluxmodeldata packages. Users must install the new versions available at https://hscdata.mtk.nao.ac.jp/hsc_bin_dist/pfs/fluxmodeldata-ambre-20230428-small.tar.xz and https://hscdata.mtk.nao.ac.jp/hsc_bin_dist/pfs/fluxmodeldata-ambre-20230428-full.tar.xz .