### PR TITLE
feat: add epch/pmRa/pmDec/parallax to PfsDesign/PfsConfig (DAMD-137)

### DIFF
--- a/python/pfs/drp/stella/synthetic.py
+++ b/python/pfs/drp/stella/synthetic.py
@@ -303,6 +303,11 @@ def makeSyntheticPfsConfig(config, pfsDesignId, visit, rng=None,
 
     fiberStatus = np.full_like(targetType, FiberStatus.GOOD)
 
+    epoch = np.full(shape=numFibers, fill_value="J2000.0")
+    pmRa = np.full(shape=numFibers, fill_value=0.0, dtype=np.float32)
+    pmDec = np.full(shape=numFibers, fill_value=0.0, dtype=np.float32)
+    parallax = np.full(shape=numFibers, fill_value=1e-5, dtype=np.float32)
+
     fiberMagnitude = [22.0, 23.5, 25.0, 26.0]
     fluxes = [(f * u.ABmag).to_value(u.nJy) for f in fiberMagnitude]
 
@@ -329,6 +334,7 @@ def makeSyntheticPfsConfig(config, pfsDesignId, visit, rng=None,
                      posAng.asDegrees(),
                      arms,
                      fiberId, tract, patch, ra, dec, catId, objId, targetType, fiberStatus,
+                     epoch, pmRa, pmDec, parallax,
                      fiberFlux, psfFlux, totalFlux,
                      fiberFluxErr, psfFluxErr, totalFluxErr,
                      filterNames, pfiCenter, pfiNominal, GuideStars.empty())

--- a/tests/test_FitFocalPlaneTask.py
+++ b/tests/test_FitFocalPlaneTask.py
@@ -57,8 +57,13 @@ class FitFocalPlaneTaskTestCase(lsst.utils.tests.TestCase):
         flux = [np.zeros(0, dtype=float)]*self.numFibers
         filterNames = [[]]*self.numFibers
         position = self.rng.uniform(size=(self.numFibers, 2))
+        epoch = np.full(shape=self.numFibers, fill_value="J2000.0")
+        pmRa = np.full(shape=self.numFibers, fill_value=0.0, dtype=np.float32)
+        pmDec = np.full(shape=self.numFibers, fill_value=0.0, dtype=np.float32)
+        parallax = np.full(shape=self.numFibers, fill_value=1e-5, dtype=np.float32)
         self.pfsConfig = PfsConfig(123456789, 54321, 0.0, 0.0, 0.0, "brn", fiberId, tract, patch,
                                    radec, radec, catId, objId, targetType, fiberStatus,
+                                   epoch, pmRa, pmDec, parallax,
                                    flux, flux, flux, flux, flux, flux, filterNames, position, position, None)
 
     def fit(self, **kwargs) -> FocalPlaneFunction:

--- a/tests/test_fitBroadbandSED.py
+++ b/tests/test_fitBroadbandSED.py
@@ -70,6 +70,10 @@ class FitBroadbandSEDTestCase(lsst.utils.tests.TestCase):
             objId=random.randint(0x8000_0000_0000_0000, size=(nFibers,), dtype=numpy.int64),
             targetType=random.choice(allTargetTypes, size=(nFibers,)),
             fiberStatus=random.choice(allFiberStatuses, size=(nFibers,)),
+            epoch=numpy.full(nFibers, "J2000.0"),
+            pmRa=random.uniform(low=0, high=100, size=nFibers),  # mas/yr
+            pmDec=random.uniform(low=0, high=100, size=nFibers),  # mas/yr
+            parallax=random.uniform(low=1e-5, high=10, size=nFibers),  # mas
             fiberFlux=fiberFlux,
             psfFlux=fiberFlux,
             totalFlux=fiberFlux,

--- a/tests/test_fitPfsFluxReference.py
+++ b/tests/test_fitPfsFluxReference.py
@@ -186,6 +186,11 @@ class FitPfsFluxReferenceTestCase(lsst.utils.tests.TestCase):
 
         fiberStatus = np.full(fiberId.shape, FiberStatus.GOOD, dtype=int)
 
+        epoch = np.full(shape=fiberId.shape, fill_value="J2000.0")
+        pmRa = np.full(shape=fiberId.shape, fill_value=0.0, dtype=np.float32)
+        pmDec = np.full(shape=fiberId.shape, fill_value=0.0, dtype=np.float32)
+        parallax = np.full(shape=fiberId.shape, fill_value=1e-5, dtype=np.float32)
+
         fiberFlux = np.copy(flux)
         psfFlux = np.copy(flux)
         totalFlux = np.copy(flux)
@@ -215,6 +220,10 @@ class FitPfsFluxReferenceTestCase(lsst.utils.tests.TestCase):
             objId,
             targetType,
             fiberStatus,
+            epoch,
+            pmRa,
+            pmDec,
+            parallax,
             fiberFlux,
             psfFlux,
             totalFlux,


### PR DESCRIPTION
I created a relevant changes for datamodel (DAMD-137). I ran scons with the following setup. I don't see errors related to PfsDesign/PfsConfig, but there are some errors in the log. 

```
source /work/stack/loadLSST.zsh
setup pfs_pipe2d w.2023.29
setup -jr .  # at datamodel and drp_stella
scons 2>&1 | tee scons_DAMD-137-003.log
```
[scons_DAMD-137-003.log](https://github.com/Subaru-PFS/drp_stella/files/12075283/scons_DAMD-137-003.log)

