### PR TITLE
PIPE2D-1301: reduceProfiles: update following reduceExposure API change

### DIFF
--- a/python/pfs/drp/stella/lsf.py
+++ b/python/pfs/drp/stella/lsf.py
@@ -737,12 +737,13 @@ class ExtractionLsf(Lsf):
         """
         detMap = self.psf.getDetectorMap()
         xx = detMap.getXCenter(self.fiberId, yy)
-        psfImage = self.psf.computeKernelImage(Point2D(xx, yy)).convertF()
+        psfImage = MaskedImageF(self.psf.computeKernelImage(Point2D(xx, yy)).convertF())
+        psfImage.variance.set(1.0)
         xy0 = psfImage.getXY0()
         psfImage.setXY0(xy0 + Extent2I(int(xx + 0.5), int(yy + 0.5)))  # So extraction works properly
         traces = FiberTraceSet(1)
         traces.add(self.fiberTrace)
-        spectra = traces.extractSpectra(MaskedImageF(psfImage))
+        spectra = traces.extractSpectra(psfImage)
         assert len(spectra) == 1
         return Kernel1D(spectra[0].spectrum, -xy0.getY())
 
@@ -773,11 +774,12 @@ class ExtractionLsf(Lsf):
         """
         detMap = self.psf.getDetectorMap()
         xx = detMap.getXCenter(self.fiberId, yy)
-        psfImage = self.psf.computeImage(Point2D(xx, yy)).convertF()
+        psfImage = MaskedImageF(self.psf.computeImage(Point2D(xx, yy)).convertF())
+        psfImage.variance.set(1.0)
         psfBox = psfImage.getBBox()
         traces = FiberTraceSet(1)
         traces.add(self.fiberTrace)
-        spectra = traces.extractSpectra(MaskedImageF(psfImage))
+        spectra = traces.extractSpectra(psfImage)
         assert len(spectra) == 1
         array = np.zeros(self.length)
         yMin = max(psfBox.getMinY(), 0)

--- a/python/pfs/drp/stella/reduceProfiles.py
+++ b/python/pfs/drp/stella/reduceProfiles.py
@@ -188,10 +188,10 @@ class ReduceProfilesTask(CmdLineTask):
         profiles.replaceFibers(self.config.replaceFibers, self.config.replaceNearest)
 
         normList = [self.processExposure(ref) for ref in normRefList]
-        normExp = self.combine([norm.exposureList[0] for norm in normList])
+        normExp = self.combine([norm.exposure for norm in normList])
 
         if self.config.doAdjustDetectorMap:
-            detectorMap = normList[0].detectorMapList[0]
+            detectorMap = normList[0].detectorMap
             traces = self.centroidTraces.run(normExp, detectorMap, normList[0].pfsConfig)
             lines = tracesToLines(detectorMap, traces, self.config.traceSpectralError)
             detectorMap = self.adjustDetectorMap.run(
@@ -234,8 +234,8 @@ class ReduceProfilesTask(CmdLineTask):
         if all(dataRef.datasetExists(name) for name in require):
             self.log.info("Reading existing data for %s", dataRef.dataId)
             return Struct(
-                exposureList=[dataRef.get("calexp")],
-                detectorMapList=[dataRef.get("detectorMap_used")],
+                exposure=dataRef.get("calexp"),
+                detectorMap=dataRef.get("detectorMap_used"),
                 pfsConfig=dataRef.get("pfsConfig"),
             )
         return self.reduceExposure.runDataRef(dataRef)

--- a/src/FiberTraceSet.cc
+++ b/src/FiberTraceSet.cc
@@ -181,7 +181,8 @@ SpectrumSet FiberTraceSet<ImageT, MaskT, VarianceT>::extractSpectra(
                 if (modelValue > minFracMask) {
                     maskResult[ii] |= maskValue;
                 }
-                if ((maskValue & badBitMask) || !std::isfinite(imageValue) || !std::isfinite(varianceValue)) {
+                if ((maskValue & badBitMask) || !std::isfinite(imageValue) || !std::isfinite(varianceValue) ||
+                    varianceValue <= 0) {
                     continue;
                 }
                 double const m2 = std::pow(modelValue, 2);
@@ -248,7 +249,7 @@ SpectrumSet FiberTraceSet<ImageT, MaskT, VarianceT>::extractSpectra(
                     ImageT const imageValue = dataImage(xData, yData);
                     VarianceT const varianceValue = dataVariance(xData, yData);
                     if ((maskValue & badBitMask) || !std::isfinite(imageValue) ||
-                        !std::isfinite(varianceValue)) {
+                        !std::isfinite(varianceValue) || varianceValue == 0) {
                         continue;
                     }
                     double const iModel = iModelImage(xi, iyModel)/iNorm;


### PR DESCRIPTION
reduceExposure was previously updated to operate on a single exposure at a time rather than lists. It seems there weren't corresponding changes in reduceProfiles.