### PR TITLE
PIPE2D-1362: fitFluxCal should correct seeing variation

### DIFF
--- a/python/pfs/drp/stella/datamodel/pfsFiberArray.py
+++ b/python/pfs/drp/stella/datamodel/pfsFiberArray.py
@@ -87,9 +87,7 @@ class PfsFiberArray(pfs.datamodel.PfsFiberArray, PfsSimpleSpectrum):
         with np.errstate(invalid="ignore"):
             self.flux *= rhs
             self.sky *= rhs
-            rhsSquared = rhs**2
-            for ii in range(3):
-                self.covar[:, ii, :]*rhsSquared
+            self.covar *= (rhs**2).reshape(1, -1)
         return self
 
     def __itruediv__(self, rhs: Union[float, np.ndarray]) -> "PfsFiberArray":

--- a/python/pfs/drp/stella/focalPlaneFunction.py
+++ b/python/pfs/drp/stella/focalPlaneFunction.py
@@ -401,9 +401,7 @@ class ConstantFocalPlaneFunction(FocalPlaneFunction):
             for wl, resamp in zip(wavelengths, doResample)
         ]
         variances = [
-            interpolateVariance(self.wavelength, self.variance, wl)
-            if resamp
-            else self.variance
+            interpolateVariance(self.wavelength, self.variance, wl) if resamp else self.variance
             for wl, resamp in zip(wavelengths, doResample)
         ]
         return Struct(values=np.array(values), masks=np.array(masks), variances=np.array(variances))

--- a/python/pfs/drp/stella/focalPlaneFunction.py
+++ b/python/pfs/drp/stella/focalPlaneFunction.py
@@ -254,6 +254,8 @@ class FocalPlaneFunction(ABC):
             Function read from FITS file.
         """
         subs = {ss.DamdClass: ss for ss in subclasses(cls)}
+        if hasattr(cls, "DamdClass"):
+            subs[cls.DamdClass] = cls
         func = PfsFocalPlaneFunction.readFits(filename)
         return subs[type(func)](datamodel=func)
 

--- a/python/pfs/drp/stella/focalPlaneFunction.py
+++ b/python/pfs/drp/stella/focalPlaneFunction.py
@@ -9,6 +9,7 @@ from pfs.datamodel import (
     PfsFocalPlaneFunction,
     PfsOversampledSpline,
     PfsPolynomialPerFiber,
+    PfsFluxCalib,
 )
 from pfs.datamodel.utils import subclasses
 from pfs.drp.stella.datamodel import PfsFiberArraySet
@@ -19,6 +20,10 @@ from scipy.stats import binned_statistic
 from .math import NormalizedPolynomial1D, calculateMedian, solveLeastSquaresDesign
 from .struct import Struct
 from .utils.math import robustRms
+from .utils.polynomialND import NormalizedPolynomialND
+
+from typing import Callable
+
 
 __all__ = (
     "FocalPlaneFunction",
@@ -26,6 +31,7 @@ __all__ = (
     "OversampledSpline",
     "BlockedOversampledSpline",
     "PolynomialPerFiber",
+    "FluxCalib",
 )
 
 
@@ -997,3 +1003,141 @@ class PolynomialPerFiber(FocalPlaneFunction):
         rms = np.array([np.full_like(wavelengths[ii], self.rms[ff]) for ii, ff in enumerate(fiberIds)])
         masks = ~np.isfinite(values) | ~np.isfinite(rms)
         return Struct(values=values, variances=rms**2, masks=masks)
+
+
+class FluxCalib(FocalPlaneFunction):
+    r"""Flux calibration vector such that pfsMerged divided by fluxCalib
+    will be the calibrated spectra.
+
+    This is the product of a ConstantFocalPlaneFunction ``h(\lambda)``
+    multiplied by the exponential of a trivariate polynomial
+    ``g(x, y, \lambda)``, where ``(x, y)`` is the fiber position.
+    ``h(\lambda)`` represents the average shape of flux calibration vectors
+    up to ``exp g(x, y, \lambda)``. ``exp g(x, y, \lambda)``, which is
+    expected to be almost independent of ``\lambda``, represents the overall
+    height of a flux calibration vector at ``(x, y)``. The height varies from
+    fiber to fiber (or, according to ``(x, y)``) because of imperfect fiber
+    positioning. ``g(x, y, \lambda)`` indeed depends slightly on ``\lambda``
+    because seeing depends on wavelength.
+
+    Parameters
+    ----------
+    polyParams : `numpy.ndarray` of `float`
+        Parameters used by ``NormalizedPolynomialND`` in ``drp_stella``.
+        These parameters define ``g(x, y, \lambda)``.
+    polyMin : `numpy.ndarray` of `float`, shape ``(3,)``
+        Vertex of the rectangular-parallelepipedal domain of the polynomial
+        at which ``(x, y, \lambda)`` are minimal.
+    polyMax : `numpy.ndarray` of `float`, shape ``(3,)``
+        Vertex of the rectangular-parallelepipedal domain of the polynomial
+        at which ``(x, y, \lambda)`` are maximal.
+    constantFocalPlaneFunction : `PfsConstantFocalPlaneFunction`
+        ``h(\lambda)`` as explaned above.
+    """
+
+    DamdClass = PfsFluxCalib
+
+    def __init__(self, *args, datamodel: Optional[PfsFluxCalib] = None, **kwargs):
+        super().__init__(*args, datamodel=datamodel, **kwargs)
+        self.constantFocalPlaneFunction = ConstantFocalPlaneFunction(
+            datamodel=self._damdObj.constantFocalPlaneFunction,
+        )
+
+    @classmethod
+    def fitArrays(
+        cls,
+        fiberId: np.ndarray,
+        wavelengths: np.ndarray,
+        values: np.ndarray,
+        masks: np.ndarray,
+        variances: np.ndarray,
+        positions: np.ndarray,
+        *,
+        robust: bool,
+        fitter: Callable,
+        **kwargs,
+    ) -> "FluxCalib":
+        """Fit a spectral function on the focal plane to arrays
+
+        We leave an actual fitting algorithm to``fitter`` argument
+        because the algorithm we currently have requires many things that
+        ``focalPlaneFunction.py`` should not know.
+
+        Parameters
+        ----------
+        fiberId : `numpy.ndarray` of `int`, shape ``(N,)``
+            Fiber identifiers.
+        wavelengths : `numpy.ndarray` of `float`, shape ``(N, M)``
+            Wavelength array. The wavelength array for all the inputs must be
+            identical.
+        values : `numpy.ndarray` of `float`, shape ``(N, M)``
+            Values to fit.
+        masks : `numpy.ndarray` of `bool`, shape ``(N, M)``
+            Boolean array indicating values to ignore from the fit.
+        variances : `numpy.ndarray` of `float`, shape ``(N, M)``
+            Variance values to use in fit.
+        positions : `numpy.ndarray` of `float`, shape ``(N, 2)``
+            Focal-plane positions of fibers.
+        robust : `bool`
+            Perform robust fit? A robust fit should provide an accurate answer
+            in the presense of outliers, even if the answer is less precise
+            than desired. A non-robust fit should provide the most precise
+            answer while assuming there are no outliers.
+        fitter : `Callable`
+            A function that actually performs fitting.
+            This function is called like
+            ``fitter(fiberId, wavelengths, ..., positions, robust=robust, **kwargs)``
+            and returns an instance of `FluxCalib`.
+        **kwargs : `dict`
+            Fitting parameters.
+
+        Returns
+        -------
+        fit : `FluxCalib`
+            Function fit to input arrays.
+        """
+        return fitter(fiberId, wavelengths, values, masks, variances, positions, robust=robust, **kwargs)
+
+    def evaluate(self, wavelengths: np.ndarray, fiberIds: np.ndarray, positions: np.ndarray) -> Struct:
+        """Evaluate the function at the provided positions
+
+        We interpolate the variance without doing any of the usual error
+        propagation. Since there is likely some amount of unknown covariance
+        (if only from resampling to a common wavelength scale), following the
+        usual error propagation formulae as if there is no covariance would
+        artificially suppress the noise estimates.
+
+        Parameters
+        ----------
+        wavelengths : `numpy.ndarray` of shape ``(N, M)``
+            Wavelength arrays.
+        fiberIds : `numpy.ndarray` of `int` of shape ``(N,)``
+            Fiber identifiers.
+        positions : `numpy.ndarray` of shape ``(N, 2)``
+            Focal-plane positions at which to evaluate.
+
+        Returns
+        -------
+        values : `numpy.ndarray` of `float`, shape ``(N, M)``
+            Vector function evaluated at each position.
+        masks : `numpy.ndarray` of `bool`, shape ``(N, M)``
+            Indicates whether the value at each position is valid.
+        variances : `numpy.ndarray` of `float`, shape ``(N, M)``
+            Variances for each position.
+        """
+        assert len(wavelengths) == len(positions)
+        nFibers, nSamples = wavelengths.shape
+
+        poly = NormalizedPolynomialND(self.polyParams, self.polyMin, self.polyMax)
+
+        x = np.empty(shape=(nFibers, nSamples, 3), dtype=float)
+        x[:, :, :2] = positions.reshape(nFibers, 1, 2)
+        x[:, :, 2] = wavelengths
+
+        scales = np.exp(poly(x))
+
+        retvalue = self.constantFocalPlaneFunction.evaluate(wavelengths, fiberIds, positions)
+        retvalue.values *= scales
+        retvalue.variances *= np.square(scales)
+
+        return retvalue

--- a/python/pfs/drp/stella/utils/polynomialND.py
+++ b/python/pfs/drp/stella/utils/polynomialND.py
@@ -176,6 +176,55 @@ class NormalizedPolynomialND:
         else:
             return self._max
 
+    def getParams(self) -> np.ndarray:
+        """Get the parameters of this polynomial.
+
+        Returns
+        -------
+        params : `np.ndarray` of `float`, shape ``(nParams,)``
+            Parameters.
+        """
+        return self._params
+
+    @staticmethod
+    def getParamsFromLowerVariatePoly(params: np.ndarray, variables: List[Union[int, None]]) -> np.ndarray:
+        """Get the parameters for N-variate polynomial that is equal to the
+        M-variate polynomial whose parameters are ``params`` (N >= M).
+
+        Parameters
+        ----------
+        params : `np.ndarray`
+            Parameters for M-variate polynomial.
+        variables : `List[int|None]`
+            Mapping of variables from N-variate one to M-variate one.
+            ``i``-th variable of N-variate one is identified with
+            ``variables[i]``-th variable of M-variate one. If ``variables[i]``
+            is ``None``, then ``i``-th variable of N-variate one does not
+            appear in M-variate one.
+
+        Returns
+        -------
+        paramsN : `np.ndarray`
+            Parameters for N-variate polynomial.
+        """
+        nVarsM = max(i for i in variables if i is not None) + 1
+        nParamsM = len(params)
+        order = getPolynomialOrder(nVarsM, nParamsM)
+        nVarsN = len(variables)
+        nParamsN = math.comb(nVarsN + order, nVarsN)
+
+        exponentsM = getExponents(order, nVarsM)
+        exponentsN = getExponents(order, nVarsN)
+
+        exponentsN_inverse = {tuple(v): k for k, v in enumerate(exponentsN)}
+        paramsN = np.zeros(shape=(nParamsN,), dtype=float)
+        for indexM, exponsM in enumerate(exponentsM):
+            exponsN = tuple((exponsM[i] if i is not None else 0) for i in variables)
+            indexN = exponentsN_inverse[exponsN]
+            paramsN[indexN] = params[indexM]
+
+        return paramsN
+
 
 def getPolynomialOrder(nVars: int, nParams: int) -> int:
     """Find the ``order`` of an ``nVars``-variate polynomial

--- a/python/pfs/drp/stella/utils/polynomialND.py
+++ b/python/pfs/drp/stella/utils/polynomialND.py
@@ -1,0 +1,287 @@
+import numpy as np
+
+import math
+
+from typing import List, Union
+from typing import overload
+
+
+__all__ = ["NormalizedPolynomialND"]
+
+
+class NormalizedPolynomialND:
+    """``nVars``-variate polynomial whose domain is normalized to ``[-1, 1]^nVars``.
+
+    The suffix "D" ("Double") is after NormalizedPolynomial1D and -2D.
+
+    ``nVars`` is guessed from ``min`` and ``max``. If both ``min`` and ``max``
+    are scalars, then all appearances of ``nVars`` in docstrings of this class
+    should be read "", or the empty string. For example, ``(nVars,)`` should
+    be read ``()`` and ``(a, b, nVars)`` should be read ``(a, b)``.
+
+    Parameters
+    ----------
+    params : `np.ndarray|int`
+        Parameters (coefficients) of a polynomial.
+        If this argument is of `int` type, it is interpreted as a polynomial
+        order ``order`` and a zero polynomial of order ``order`` is created.
+    min : `np.ndarray`, shape ``(nVars,)``
+        Any vertex of the hyperrectangular domain.
+    max : `np.ndarray`, shape ``(nVars,)``
+        The vertex, of the hyperrectangular domain, that is the farthest
+        from ``min``.
+    """
+
+    @overload
+    def __init__(self, order: int, min: Union[np.ndarray, float], max: Union[np.ndarray, float]) -> None:
+        ...
+
+    @overload
+    def __init__(
+        self, params: np.ndarray, min: Union[np.ndarray, float], max: Union[np.ndarray, float]
+    ) -> None:
+        ...
+
+    def __init__(self, params, min, max):
+        self._min = np.minimum(min, max, dtype=float)
+        self._max = np.maximum(min, max, dtype=float)
+
+        if self._min.ndim == 0:
+            self._isScalarDomain = True
+            self._min = self._min.reshape(1)
+            self._max = self._max.reshape(1)
+        elif self._min.ndim == 1:
+            self._isScalarDomain = False
+        else:
+            raise ValueError("`min` and `max` must be at most one-dimensional.")
+
+        nVars = len(self._min)
+        if nVars == 0:
+            raise ValueError("0-variate polynomial is not allowed.")
+
+        params_arr = np.asarray(params)
+        if params_arr.ndim == 0:
+            # `params` is not parameters but a polynomial order in fact.
+            order = int(params)
+            params = np.zeros(shape=(math.comb(nVars + order, nVars),), dtype=float)
+        elif params_arr.ndim == 1:
+            # `params` are parameters indeed.
+            params = np.asarray(params_arr, dtype=float)
+            order = getPolynomialOrder(nVars, len(params))
+        else:
+            raise ValueError("`params` must be one-dimensional.")
+
+        self._order = order
+        self._params = params
+        self._scale = 1.0 / (self._max - self._min)
+        self._exponents = getExponents(order, nVars)
+
+    def __call__(self, x: Union[np.ndarray, float]) -> Union[np.ndarray, float]:
+        """Evaluate the polynomial at ``x``.
+
+        Parameters
+        ----------
+        x : `np.ndarray` of `float`, shape ``(..., nVars)``
+            Point at which to evaluate the polynomial.
+
+        Returns
+        -------
+        y : `np.ndarray` of `float`, shape ``(...)``
+            ``f(x)``. The shape of the return value is that of ``x`` with
+            the last dimension stripped.
+        """
+        xToExponents = self.getDFuncDParameters(x)
+        return xToExponents @ self._params
+
+    def getDFuncDParameters(self, x: Union[np.ndarray, float]) -> np.ndarray:
+        """Get ``df / d params`` (it is not ``df/dx``) at ``x``.
+
+        Because the polynomial is
+            f = sum(
+                params[i] * x[0]**expons[i][0] * ... * params[i] * x[nVars-1]**expons[i][nVars-1]
+                for i in range(len(params))
+            )
+        ``df / d params[i]`` is
+        ``x[0]**expons[i][0] * ... * params[i] * x[nVars-1]**expons[i][nVars-1]``.
+
+        Parameters
+        ----------
+        x : `np.ndarray` of `float`, shape ``(..., nVars)``
+            Point at which to evaluate ``df / d params``
+
+        Returns
+        -------
+        dFuncDParams : `np.ndarray` of `float`, shape ``(..., nParams)``
+            List of ``df / d params[i]`` for all [i].
+        """
+        x = np.array(x, dtype=float, copy=True)
+        nVars = len(self._min)
+
+        if self._isScalarDomain:
+            x = x.reshape(x.shape + (1,))
+        else:
+            if x.ndim == 0 or x.shape[-1] != nVars:
+                raise ValueError(f"Size of the last dimension of `x` must be {nVars}")
+
+        min = self._min.reshape((1,) * (x.ndim - 1) + (nVars,))
+        scale = self._scale.reshape((1,) * (x.ndim - 1) + (nVars,))
+
+        x -= min
+        x *= scale
+
+        # Note: If x.shape is (a, b, ..., c, nVars),
+        # then xShape will be (a, b, ..., c, 1, nVars)
+        xShape = x.shape[:-1] + (1,) + x.shape[-1:]
+        # Note: If _exponents.shape is (nParams, nVars),
+        # then exponentsShape will be (1, 1, ..., 1, nParams, nVars).
+        exponentsShape = (1,) * (x.ndim - 1) + self._exponents.shape
+
+        # xToExponents has shape (a, b, ..., c, nParams).
+        xToExponents = np.prod(x.reshape(xShape) ** self._exponents.reshape(exponentsShape), axis=(-1,))
+        return xToExponents
+
+    def getOrder(self) -> int:
+        """Get the polynomial order
+
+        Returns
+        -------
+        order : `int`
+            Polynomial order.
+        """
+        return self._order
+
+    def getMin(self) -> Union[np.ndarray, float]:
+        """Get the bottom-left vertex of the hyperrectangular domain.
+
+        Returns
+        -------
+        min : `np.ndarray` of `float`, shape ``(nVars,)``
+            Bottom-left vertex.
+        """
+        if self._isScalarDomain:
+            return float(self._min)
+        else:
+            return self._min
+
+    def getMax(self) -> Union[np.ndarray, float]:
+        """Get the top-bottom vertex of the hyperrectangular domain.
+
+        Returns
+        -------
+        max : `np.ndarray` of `float`, shape ``(nVars,)``
+            top-bottom vertex.
+        """
+        if self._isScalarDomain:
+            return float(self._max)
+        else:
+            return self._max
+
+
+def getPolynomialOrder(nVars: int, nParams: int) -> int:
+    """Find the ``order`` of an ``nVars``-variate polynomial
+    that has ``nParams`` parameters.
+
+    It is ``order`` that satisfies ``math.comb(nVars + order, nVars) == nParams``.
+    """
+    if nVars <= 0:
+        raise ValueError("nVars must be >= 1")
+    if nParams <= 0:
+        raise ValueError("nParams must be >= 1")
+
+    # We don't expect ``order`` is very large. Let us brute-force it.
+    step = 5
+    startOrder = 0
+    stopOrder = startOrder + step
+    while True:
+        n = math.comb(nVars + stopOrder, nVars)
+        if n >= nParams:
+            break
+        startOrder = stopOrder
+        stopOrder += step
+
+    if n == nParams:
+        return stopOrder
+
+    for order in range(startOrder, stopOrder):
+        n = math.comb(nVars + order, nVars)
+        if n >= nParams:
+            if n == nParams:
+                return order
+            else:
+                break
+
+    raise ValueError(f"There cannot be a {nVars}-variate polynomial with {nParams} parameters")
+
+
+def getExponents(order: int, nVars: int) -> np.ndarray:
+    """Get list of exponents ``(p[0],.., p[nVars-1])`` of all possible terms
+    ``x[0]**p[0] * ... * x[nVars-1]**p[nVars-1]`` in an ``nVars``-variate
+    polynomial.
+
+    The returned list is sorted so that
+      - the elements are arranged in descending order of ``sum(p)``.
+      - Ties are broken according reversely to tuple order of ``(p[0],...,p[nVars-1])``
+
+    Parameters
+    ----------
+    order : `int`
+        Polynomial order.
+    nVars : `int`
+        Number of variables of the polynomial.
+
+    Returns
+    -------
+    exponents : `np.ndarray` of `int`, shape ``(nTerms, nVars)``
+        List of exponents ``(p[0],.., p[nVars])`` for all possible terms
+        ``x[0]**p[0] * ... * x[nVars-1]**p[nVars-1]``.
+    """
+
+    def key(expons: List[int]) -> List[int]:
+        """Key for sorting.
+
+        Parameters
+        ----------
+        expons : `List[int]`
+            A tuple of exponents``(p[0],.., p[nVars-1])`` as described
+            in the docstring of the parent function.
+
+        Returns
+        -------
+        key : `List[int]`
+            Key by which to sort the list.
+        """
+        return [-sum(expons)] + [-p for p in expons]
+
+    exponents = _getExponents(order, nVars)
+    exponents.sort(key=key)
+    return np.array(exponents, dtype=int)
+
+
+def _getExponents(order: int, nVars: int) -> List[List[int]]:
+    """Get list of exponents ``(p[0],.., p[nVars-1])`` of all possible terms
+    ``x[0]**p[0] * ... * x[nVars-1]**p[nVars-1]`` in an ``nVars``-variate
+    polynomial.
+
+    Parameters
+    ----------
+    order : `int`
+        Polynomial order.
+    nVars : `int`
+        Number of variables of the polynomial.
+
+    Returns
+    -------
+    exponents : `List[List[int]]`, shape ``(nTerms, nVars)``
+        List of exponents ``(p[0],.., p[nVars])`` for all possible terms
+        ``x[0]**p[0] * ... * x[nVars-1]**p[nVars-1]``.
+    """
+    if nVars >= 2:
+        exponents: List[List[int]] = []
+        for p in range(order + 1):
+            subexponents = _getExponents(order - p, nVars - 1)
+            for subexpons in subexponents:
+                subexpons.append(p)
+            exponents.extend(subexponents)
+        return exponents
+    else:
+        return [[p] for p in range(order + 1)]

--- a/tests/test_polynomialND.py
+++ b/tests/test_polynomialND.py
@@ -1,0 +1,123 @@
+import numpy as np
+
+import lsst.utils.tests
+from pfs.drp.stella.tests.utils import runTests, methodParameters
+from pfs.drp.stella.utils.polynomialND import NormalizedPolynomialND, getPolynomialOrder, getExponents
+
+import math
+
+eps = np.nextafter(np.float64(1), np.inf) - np.float64(1)
+
+
+class NormalizedPolynomialNDTestCase(lsst.utils.tests.TestCase):
+    """NormalizedPolynomialND test case"""
+
+    def testGetPolynomialOrder(self):
+        """Test getPolynomialOrder(nVars, nParams)"""
+        with self.assertRaises(ValueError):
+            getPolynomialOrder(0, 1)
+
+        with self.assertRaises(ValueError):
+            getPolynomialOrder(1, 0)
+
+        with self.assertRaises(ValueError):
+            getPolynomialOrder(4, 2)
+
+        self.assertEqual(getPolynomialOrder(4, math.comb(4 + 9, 9)), 9)
+        self.assertEqual(getPolynomialOrder(5, math.comb(5 + 10, 10)), 10)
+
+    @methodParameters(
+        order=(1, 1, 7, 7),
+        nVars=(1, 5, 1, 5),
+    )
+    def testGetExponents(self, order, nVars):
+        """Test getExponents(order, nVars)"""
+        exponents = getExponents(order, nVars)
+        self.assertIs(exponents.dtype, np.array([1]).dtype)
+        self.assertEqual(exponents.shape, (math.comb(order + nVars, nVars), nVars))
+
+        self.assertTrue(np.all(exponents >= 0))
+        self.assertTrue(np.all(np.sum(exponents, axis=(1,)) <= order))
+
+        self.assertTrue(
+            all(
+                (sum(p),) + tuple(p) > (sum(q),) + tuple(q)
+                for p, q in zip(exponents[:-1, :], exponents[1:, :])
+            ),
+        )
+
+    def testUnivariate(self):
+        """Test `NormalizedPolynomialND` when N = 1
+
+        ``NormalizedPolynomialND(params, left, right)``, when ``left`` and
+        ``right`` are scalars, behaves differently from
+        ``NormalizedPolynomialND(params, [left], [right])``.
+        We test the former here.
+        """
+        np.random.seed(54321)
+
+        order = 5
+        nVars = 1
+        nParams = math.comb(order + nVars, nVars)
+        nPoints = 4
+        left = -3.0
+        right = 2.0
+
+        params = np.random.uniform(-2, 2, size=(nParams,))
+        x = np.random.uniform(-2, 2, size=(nPoints,))
+
+        poly = NormalizedPolynomialND(params, left, right)
+
+        self.assertEqual(poly(x[0]).shape, ())
+        self.assertEqual(poly(x).shape, (nPoints,))
+
+        self.assertFloatsAlmostEqual(poly(x), poly(x.reshape(-1, 2, nVars)).reshape(-1), rtol=16 * eps)
+
+        self.assertFloatsAlmostEqual(poly(x)[0], poly(x[0]), rtol=16 * eps)
+
+        normalizedX1 = (x[1] - left) / (right - left)
+        exponents = np.asarray(getExponents(order, nVars))[:, 0]
+
+        self.assertFloatsAlmostEqual(normalizedX1**exponents @ params, poly(x[1]), rtol=16 * eps)
+
+    def testMultivariate(self):
+        """Test `NormalizedPolynomialND` when N > 1"""
+        np.random.seed(12345)
+
+        order = 5
+        nVars = 3
+        nParams = math.comb(order + nVars, nVars)
+        nPoints = 4
+        minVertex = np.array([-3, -4, -5], dtype=float)
+        maxVertex = np.array([2, 1, 6], dtype=float)
+
+        params = np.random.uniform(-2, 2, size=(nParams,))
+        x = np.random.uniform(-2, 2, size=(nPoints, nVars))
+
+        poly = NormalizedPolynomialND(params, minVertex, maxVertex)
+
+        self.assertFloatsAlmostEqual(
+            poly(x).reshape(-1), poly(x.reshape(-1, 2, nVars)).reshape(-1), rtol=16 * eps
+        )
+
+        self.assertFloatsAlmostEqual(poly(x)[0], poly(x[0, :]), rtol=16 * eps)
+
+        normalizedX1 = (x[1, :] - minVertex) / (maxVertex - minVertex)
+
+        self.assertFloatsAlmostEqual(
+            np.prod(normalizedX1.reshape(1, nVars) ** getExponents(order, nVars), axis=(1,)) @ params,
+            poly(x[1, :]),
+            rtol=16 * eps,
+        )
+
+
+class TestMemory(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    runTests(globals())


### PR DESCRIPTION
The type of fluxCal is no longer ConstantFocalPlaneFunction but another
subclass of FocalPlaneFunction. It consists of (1) an average flux
calibration vector up to scales and (2) the exponential of a polynomial
of (x, y, lambda), which is expected to be a gently varying function
of fiber position and wavelength, representing scale (i.e. overall
height of a flux calibration vector) that vary according to fiber
position in the field of view, and seeing variation according to
wavelength.