### PR TITLE
PIPE2D-1446: fitPfsFluxReference: Use diff. w.l.ranges for mid- and low-res spectra

### DIFF
--- a/tests/test_fitPfsFluxReference.py
+++ b/tests/test_fitPfsFluxReference.py
@@ -91,7 +91,7 @@ class FitPfsFluxReferenceTestCase(lsst.utils.tests.TestCase):
             self.np_random.choice(len(self.modelSet.parameters), size=nFibers, replace=False)
         ]
 
-        identity = Identity(visit=0, arm="r", spectrograph=1, pfsDesignId=0)
+        identity = Identity(visit=0, arm="brn", spectrograph=1, pfsDesignId=0)
         fiberId = np.arange(1, nFibers + 1, dtype=np.int32)
         radecs = self.getRandomLonLat(size=nFibers)
         ebvs = self.dustMap(radecs[:, 0], radecs[:, 1])


### PR DESCRIPTION
In fitting a flux reference, we use different wavelength ranges for mid-res spectra and low-res spectra. Whether spectra are mid-res or low-res is determined not by pfsConfig but by the spectra themselves because pfsConfig's information is unreliable: pfsConfig.arms may be "brn" when it should be "bmn". The reason for this is that humans may disobey pfsDesign in actual observation.