### PR TITLE
move plotFiberNorms to drp_qa tickets/PIPE2D-1486

### DIFF
--- a/python/pfs/drp/stella/background.py
+++ b/python/pfs/drp/stella/background.py
@@ -10,7 +10,7 @@ from lsst.afw.image import MaskedImage
 from pfs.datamodel import FiberStatus
 from .datamodel import PfsConfig
 from pfs.drp.stella import DetectorMap
-from .fitDistortedDetectorMap import addColorbar
+from pfs.drp.stella.utils.plotting import addColorbar
 
 __all__ = ("BackgroundConfig", "BackgroundTask")
 

--- a/python/pfs/drp/stella/datamodel/pfsFiberNorms.py
+++ b/python/pfs/drp/stella/datamodel/pfsFiberNorms.py
@@ -1,77 +1,44 @@
-from typing import Optional, Tuple, TYPE_CHECKING
-import warnings
-
-import numpy as np
+from typing import TYPE_CHECKING, Optional
 
 import pfs.datamodel
 
-from ..utils.math import robustRms
-
 if TYPE_CHECKING:
-    import matplotlib
+    from matplotlib import Figure, Axes
 
 __all__ = ("PfsFiberNorms",)
 
 
 class PfsFiberNorms(pfs.datamodel.PfsFiberNorms):
-    def plot(
-        self,
-        pfsConfig: pfs.datamodel.PfsConfig,
-        axes: Optional["matplotlib.axes.Axes"] = None,
-        lower: float = 2.5,
-        upper: float = 2.5,
-        size: float = 10,
-    ) -> Tuple["matplotlib.figure.Figure", "matplotlib.axes.Axes"]:
+    # Add the plot function as a class method.
+    def plot(self,
+             pfsConfig: pfs.datamodel.PfsConfig,
+             axes: Optional["Axes"] = None,
+             lower: float = 2.5,
+             upper: float = 2.5,
+             size: float = 10,
+             title: Optional[str] = None
+             ) -> "Figure":
         """Plot fiber normalization values
 
         Parameters
         ----------
+        fiberNorms : `PfsFiberNorms`
+            Fiber normalization values.
         pfsConfig : `pfs.datamodel.PfsConfig`
             Configuration for the PFS system
         axes : `matplotlib.axes.Axes`, optional
             Axes to plot on; if None, create a new figure and axes.
         lower, upper : `float`
-            Lower and upper bounds for plot, in units of standard deviations.
+            Lower and upper bounds for plot, in units of standard deviations. Default is 2.5.
         size : `float`
-            Size of the markers.
+            Size of the markers. Default is 10.
+        title : `str`, optional
+            Title for the plot.
 
         Returns
         -------
         fig : `matplotlib.figure.Figure`
             Figure containing the plot.
-        axes : `matplotlib.axes.Axes`
-            Axes containing the plot.
         """
-        import matplotlib
-        import matplotlib.pyplot as plt
-        import matplotlib.cm
-        from matplotlib.colors import Normalize
-        from ..fitDistortedDetectorMap import addColorbar
-
-        cmap = matplotlib.cm.coolwarm
-        if axes is None:
-            fig, axes = plt.subplots()
-        else:
-            fig = axes.figure
-
-        pfsConfig = pfsConfig.select(fiberId=self.fiberId)
-        indices = np.argsort(pfsConfig.fiberId)
-        assert np.array_equal(pfsConfig.fiberId[indices], self.fiberId)
-        xx = pfsConfig.pfiCenter[indices, 0]
-        yy = pfsConfig.pfiCenter[indices, 1]
-
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", r"All-NaN (slice|axis) encountered")
-            values = np.nanmedian(self.values, axis=1)
-        good = np.isfinite(values)
-        median = np.median(values[good])
-        rms = robustRms(values[good])
-        lower = max(median - lower*rms, np.nanmin(values))
-        upper = min(median + upper*rms, np.nanmax(values))
-        norm = Normalize(vmin=lower, vmax=upper)
-
-        axes.scatter(xx, yy, marker="o", c=values, cmap=cmap, norm=norm, s=size)
-        axes.set_aspect("equal")
-        addColorbar(fig, axes, cmap, norm, "Fiber normalization")
-
-        return fig, axes
+        from pfs.drp.qa.utils.plotting import plotFiberNorms
+        return plotFiberNorms(self, pfsConfig, axes=axes, lower=lower, upper=upper, size=size, title=title)

--- a/python/pfs/drp/stella/fiberProfileSet.py
+++ b/python/pfs/drp/stella/fiberProfileSet.py
@@ -517,7 +517,7 @@ class FiberProfileSet:
         """
         import matplotlib.pyplot as plt
         from matplotlib.colors import Normalize
-        from .fitDistortedDetectorMap import addColorbar
+        from pfs.drp.stella.utils.plotting import addColorbar
 
         stats = {fiberId: self[fiberId].calculateStatistics() for fiberId in self}
         fiberGridSize = min(fiberGridSize, len(stats))

--- a/python/pfs/drp/stella/fitDifferentialDetectorMap.py
+++ b/python/pfs/drp/stella/fitDifferentialDetectorMap.py
@@ -13,6 +13,8 @@ from lsst.pipe.base import Task, Struct
 from lsst.afw.math import LeastSquares
 
 from pfs.drp.stella import DetectorMap, DifferentialDetectorMap
+from pfs.drp.stella.utils.plotting import addColorbar
+
 from .GlobalDetectorModel import GlobalDetectorModel, GlobalDetectorModelScaling
 from .referenceLine import ReferenceLineStatus
 from .utils.math import robustRms, fitStraightLine
@@ -93,36 +95,6 @@ def calculateFitStatistics(model, lines, selection, soften=0.0):
     dof = 2*selection.sum() - model.getNumParameters(model.getDistortionOrder())
     return Struct(model=model, xResid=xResid, yResid=yResid, xRms=xWeightedRms, yRms=yWeightedRms,
                   xRobustRms=xRobustRms, yRobustRms=yRobustRms, chi2=chi2, dof=dof, soften=soften)
-
-
-def addColorbar(figure, axes, cmap, norm, label=None):
-    """Add colorbar to a plot
-
-    Parameters
-    ----------
-    figure : `matplotlib.pyplot.Figure`
-        Figure containing the axes.
-    axes : `matplotlib.pyplot.Axes`
-        Axes with the plot.
-    cmap : `matplotlib.colors.Colormap`
-        Color map.
-    norm : `matplot.colors.Normalize`
-        Normalization for color map.
-    label : `str`
-        Label to apply to colorbar.
-
-    Returns
-    -------
-    colorbar : `matplotlib.colorbar.Colorbar`
-        The colorbar.
-    """
-    import matplotlib.cm
-    from mpl_toolkits.axes_grid1 import make_axes_locatable
-    divider = make_axes_locatable(axes)
-    cax = divider.append_axes("right", size='5%', pad=0.05)
-    colors = matplotlib.cm.ScalarMappable(cmap=cmap, norm=norm)
-    colors.set_array([])
-    figure.colorbar(colors, cax=cax, orientation="vertical", label=label)
 
 
 class FitDifferentialDetectorMapConfig(Config):

--- a/python/pfs/drp/stella/fitDistortedDetectorMap.py
+++ b/python/pfs/drp/stella/fitDistortedDetectorMap.py
@@ -15,6 +15,8 @@ from lsst.geom import Box2D
 from pfs.datamodel.pfsTable import PfsTable, Column
 from pfs.drp.stella import DetectorMap, MultipleDistortionsDetectorMap
 from pfs.drp.stella import PolynomialDistortion, MosaicPolynomialDistortion
+from pfs.drp.stella.utils.plotting import addColorbar
+
 from .DistortionContinued import Distortion
 from .applyExclusionZone import getExclusionZone
 from .arcLine import ArcLineSet
@@ -248,36 +250,6 @@ def calculateFitStatistics(
                   xRobustRms=xRobustRms, yRobustRms=yRobustRms, chi2=chi2, dof=dof, num=num,
                   numParameters=numParameters, selection=xSelection, isTrace=isTrace, soften=soften,
                   xSoften=xSoften, ySoften=ySoften, **kwargs)
-
-
-def addColorbar(figure, axes, cmap, norm, label=None):
-    """Add colorbar to a plot
-
-    Parameters
-    ----------
-    figure : `matplotlib.pyplot.Figure`
-        Figure containing the axes.
-    axes : `matplotlib.pyplot.Axes`
-        Axes with the plot.
-    cmap : `matplotlib.colors.Colormap`
-        Color map.
-    norm : `matplot.colors.Normalize`
-        Normalization for color map.
-    label : `str`
-        Label to apply to colorbar.
-
-    Returns
-    -------
-    colorbar : `matplotlib.colorbar.Colorbar`
-        The colorbar.
-    """
-    import matplotlib.cm
-    from mpl_toolkits.axes_grid1 import make_axes_locatable
-    divider = make_axes_locatable(axes)
-    cax = divider.append_axes("right", size='5%', pad=0.05)
-    colors = matplotlib.cm.ScalarMappable(cmap=cmap, norm=norm)
-    colors.set_array([])
-    figure.colorbar(colors, cax=cax, orientation="vertical", label=label)
 
 
 class FittingError(RuntimeError):

--- a/python/pfs/drp/stella/utils/plotting.py
+++ b/python/pfs/drp/stella/utils/plotting.py
@@ -1,15 +1,14 @@
-import matplotlib.cm
 import numpy as np
 import matplotlib.pyplot as plt
 
 from pfs.datamodel.pfsConfig import FiberStatus, TargetType
 
-
 __all__ = ["plot2dSpectrumSlice"]
 
 
 def plot2dSpectrumSlice(exposure, pfsConfig, detectorMap, title="", r0=1980, r1=2020,
-                        nrows=3, ncols=2, overlap=50):
+                        nrows=3, ncols=2, overlap=50
+                        ):
     """Plot a slice through all the columns of a 2-D spectrum in
     nrows x ncols panels
 
@@ -23,8 +22,8 @@ def plot2dSpectrumSlice(exposure, pfsConfig, detectorMap, title="", r0=1980, r1=
     """
     fig, axs = plt.subplots(nrows, ncols, sharey=True)
     axs = axs.flatten()
-    n = len(axs)   # number of panels
-    xlen = exposure.getWidth()//n + 1
+    n = len(axs)  # number of panels
+    xlen = exposure.getWidth() // n + 1
 
     for i in range(n):
         plt.sca(axs[i])
@@ -36,14 +35,14 @@ def plot2dSpectrumSlice(exposure, pfsConfig, detectorMap, title="", r0=1980, r1=
             if fid not in pfsConfig.fiberId:
                 continue
 
-            xc = detectorMap.getXCenter(fid)[(r0 + r1)//2]
+            xc = detectorMap.getXCenter(fid)[(r0 + r1) // 2]
             ind = pfsConfig.selectFiber(fid)[0]
             color = 'red' if pfsConfig.targetType[ind] == TargetType.SUNSS_DIFFUSE else 'green'
             ls = ':' if pfsConfig.fiberStatus[ind] == FiberStatus.BROKENFIBER else '-'
 
             plt.axvline(xc, ls=ls, color=color, alpha=0.25, zorder=-1)
 
-        x01 = np.array([i*xlen - overlap, (i + 1)*xlen + overlap])
+        x01 = np.array([i * xlen - overlap, (i + 1) * xlen + overlap])
         if i == 0:
             x01 += overlap
         elif i == n - 1:

--- a/python/pfs/drp/stella/utils/plotting.py
+++ b/python/pfs/drp/stella/utils/plotting.py
@@ -1,3 +1,4 @@
+import matplotlib.cm
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -61,3 +62,33 @@ def plot2dSpectrumSlice(exposure, pfsConfig, detectorMap, title="", r0=1980, r1=
     plt.tight_layout()
 
     return fig
+
+
+def addColorbar(figure, axes, cmap, norm, label=None):
+    """Add colorbar to a plot
+
+    Parameters
+    ----------
+    figure : `matplotlib.pyplot.Figure`
+        Figure containing the axes.
+    axes : `matplotlib.pyplot.Axes`
+        Axes with the plot.
+    cmap : `matplotlib.colors.Colormap`
+        Color map.
+    norm : `matplot.colors.Normalize`
+        Normalization for color map.
+    label : `str`
+        Label to apply to colorbar.
+
+    Returns
+    -------
+    colorbar : `matplotlib.colorbar.Colorbar`
+        The colorbar.
+    """
+    import matplotlib.cm
+    from mpl_toolkits.axes_grid1 import make_axes_locatable
+    divider = make_axes_locatable(axes)
+    cax = divider.append_axes("right", size='5%', pad=0.05)
+    colors = matplotlib.cm.ScalarMappable(cmap=cmap, norm=norm)
+    colors.set_array([])
+    figure.colorbar(colors, cax=cax, orientation="vertical", label=label)


### PR DESCRIPTION
Removes the `plotFiberNorms` function.

I also moved the `addColorbar` function from both `fitDistortedDetectorMap` and `fitDifferentialDetectorMap` and moved it to `drp.stella.utils.plotting`, which I think makes more sense as it's a generic function.  I can extract this to a separate PR if needed. I have similar code in `drp_qa` already so will convert it to use this in a future `drp_qa` PR.

I also added some items to `.gitignore`.

Must be merged with https://github.com/Subaru-PFS/drp_qa/pull/21

https://pfspipe.ipmu.jp/jira/projects/PIPE2D/issues/PIPE2D-1486

~~TODO: I'll rebase the commits and test again before merge.~~ done