### PR TITLE
Remove FiberNorms plotting from measureFiberNorms.py - tickets/PIPE2D-1486

### DIFF
--- a/python/pfs/drp/stella/measureFiberNorms.py
+++ b/python/pfs/drp/stella/measureFiberNorms.py
@@ -179,6 +179,8 @@ class MeasureFiberNormsTask(CmdLineTask, PipelineTask):
         ----------
         armSpectra : `dict` mapping `int` to `list` of `pfs.datamodel.PfsArm`
             pfsArm spectra, indexed by spectrograph.
+        pfsConfig : `pfs.datamodel.PfsConfig`
+            Configuration for the PFS system.
 
         Returns
         -------


### PR DESCRIPTION
The plotting will be incorporated into a new QA script in `drp_qa` (see PR below).

Replaces #358 

Should be merged with https://github.com/Subaru-PFS/drp_qa/pull/24