### PR TITLE
PIPE2D-1558: fitFluxCal: Take spectrum's error into account during fitting

### DIFF
--- a/python/pfs/drp/stella/fitFluxCal.py
+++ b/python/pfs/drp/stella/fitFluxCal.py
@@ -276,7 +276,7 @@ class BroadbandFluxChi2:
 
             for bbFlux, bbFluxErr, filterName in self.bbFlux[fId]:
                 if np.isfinite(bbFlux) and bbFluxErr > 0:
-                    photometry = self._getFilterCurve(filterName).photometer(calibrated, quadpack=False)
+                    photometry = self._getFilterCurve(filterName).photometer(calibrated)
                     relativeErr = (bbFlux - photometry) / bbFluxErr
                     chi2 += lossFunc(relativeErr)
                     if save:
@@ -379,7 +379,7 @@ class BroadbandFluxChi2:
             )
 
             for pair in self.fiberIdToPhotometries[fId]:
-                s = self._getFilterCurve(pair.filterName).photometer(scaleArray, quadpack=False)
+                s = self._getFilterCurve(pair.filterName).photometer(scaleArray)
                 relativeErr = (pair.truth - pair.model / s) / pair.error
                 chi2 += lossFunc(relativeErr)
 

--- a/python/pfs/drp/stella/fitFluxCal.py
+++ b/python/pfs/drp/stella/fitFluxCal.py
@@ -119,7 +119,7 @@ class MinimizationMonitor:
             self.fun = fun
             self.x = np.copy(xk)
             if self.log is not None:
-                self.log.info("smallest objective ever found: %s", fun)
+                self.log.debug("smallest objective ever found: %s", fun)
 
         self.nCalls += 1
         self.window[:-1] = self.window[1:]
@@ -132,7 +132,7 @@ class MinimizationMonitor:
         variance = np.var(self.window, ddof=1)
         if variance < (self.tol * mean) ** 2:
             if self.log is not None:
-                self.log.info("Minimization stops because var(objective) is small enough.")
+                self.log.debug("Minimization stops because var(objective) is small enough.")
             raise StopIteration()
 
 
@@ -664,7 +664,7 @@ def fitFluxCalibToArrays(
     params = NormalizedPolynomialND(polyOrder, posMin, posMax).getParams()
 
     if log is not None:
-        log.info("Start phase-1 fitting...")
+        log.debug("Start phase-1 fitting...")
 
     try:
         result = minimize(objective1, params, callback=monitor1)
@@ -708,7 +708,7 @@ def fitFluxCalibToArrays(
 
     monitor2 = MinimizationMonitor(objective2, tol=tol, log=log)
     if log is not None:
-        log.info("Start phase-2 fitting...")
+        log.debug("Start phase-2 fitting...")
 
     try:
         result = minimize(objective2, params, callback=monitor2)
@@ -751,7 +751,7 @@ def fitFluxCalibToArrays(
 
     monitor3 = MinimizationMonitor(objective3, tol=tol, log=log)
     if log is not None:
-        log.info("Start phase-3 fitting...")
+        log.debug("Start phase-3 fitting...")
 
     try:
         result = minimize(objective3, params, callback=monitor3)

--- a/python/pfs/drp/stella/fitPfsFluxReference.py
+++ b/python/pfs/drp/stella/fitPfsFluxReference.py
@@ -764,6 +764,8 @@ class FitPfsFluxReferenceTask(PipelineTask):
             modelInterpolator = self.modelInterpolator
 
         bestParams: Dict[int, Struct] = {}
+        # This dict will be filled only if debug mode is on
+        whitenedModels: Dict[int, PfsSimpleSpectrum] = {}
 
         for iFiber, obsSpectrum in enumerate(fibers(pfsConfig, obsSpectra)):
             fiberId = pfsConfig.fiberId[iFiber]
@@ -804,6 +806,8 @@ class FitPfsFluxReferenceTask(PipelineTask):
                     chi square. (returned only if ``returnChisq=True``)
                 dof : `int`
                     degree of freedom. (returned only if ``returnChisq=True``)
+                whitenedModel : `PfsSimpleSpectrum`
+                    Best-fit model, whitened. (returned only if ``returnChisq=True``)
                 """
                 param = xToParam(x)  # Note: param = (teff, logg, m, alpha)
                 prior = prior1d(param[0])
@@ -821,6 +825,8 @@ class FitPfsFluxReferenceTask(PipelineTask):
                 model = modelContinuum.whiten(model)
                 chisq = calculateSpecChiSquare(obsSpectrum, model, self.getBadMask())
                 if returnChisq:
+                    # Add this member for debug output.
+                    chisq.whitenedModel = model
                     return chisq
                 else:
                     return chisq.chi2 - 2 * math.log(prior)
@@ -838,6 +844,15 @@ class FitPfsFluxReferenceTask(PipelineTask):
                 chi2=chisq.chi2,
                 dof=chisq.dof,
                 success=result.success and math.isfinite(chisq.chi2),
+            )
+
+            if self.debugInfo.doWriteWhitenedFlux:
+                whitenedModels[fiberId] = chisq.whitenedModel
+
+        if self.debugInfo.doWriteWhitenedFlux:
+            debugging.writeExtraData(
+                f"fitPfsFluxReference-output/whitenedModel-{obsSpectra.filename}.pickle",
+                whitenedModel=whitenedModels,
             )
 
         return bestParams

--- a/tests/test_fitReference.py
+++ b/tests/test_fitReference.py
@@ -1,0 +1,84 @@
+import lsst.utils.tests
+from pfs.drp.stella.tests import runTests
+
+from pfs.datamodel.masks import MaskHelper
+from pfs.datamodel.observations import Observations
+from pfs.datamodel.target import Target
+from pfs.drp.stella.datamodel import PfsSingle
+from pfs.drp.stella.fitReference import _trapezoidal, FilterCurve
+
+import numpy as np
+
+
+class FitReferenceTestCase(lsst.utils.tests.TestCase):
+    def setUp(self):
+        try:
+            self.np_random = np.random.default_rng(0x981808A8FA8A744C)
+        except AttributeError:
+            self.np_random = np.random
+            self.np_random.seed(0xF6503311)
+
+    def testTrapezoidal(self):
+        """Test ``_trapezoidal()`` method."""
+        x = np.array([2, 3, 5, 7, 11, 13, 17], dtype=float)
+        y = w = np.ones_like(x)
+        # assert _exact_ equality
+        self.assertEqual(_trapezoidal(x, y, w), x[-1] - x[0])
+
+    def testPhotometer(self):
+        """Test ``TransmissionCurve.photometer()`` method"""
+        nSamples = 50
+        wavelength = np.linspace(400, 1000, num=nSamples)
+        expectedFlux = (wavelength - wavelength[0]) * (3 / (wavelength[-1] - wavelength[0]))
+        variance = 2 + np.sin((wavelength - wavelength[0]) * (4 * np.pi / (wavelength[-1] - wavelength[0])))
+        stddev = np.sqrt(variance)
+
+        covar = np.zeros(shape=(3, nSamples))
+        covar[0, :] = variance
+
+        filterCurve = FilterCurve("i2_hsc")
+        target = Target(0, 0, "0,0", 0)
+        observations = Observations(
+            visit=np.zeros(shape=1),
+            arm=["b"],
+            spectrograph=np.ones(shape=1),
+            pfsDesignId=np.zeros(shape=1),
+            fiberId=np.zeros(shape=1),
+            pfiNominal=np.zeros(shape=(1, 2)),
+            pfiCenter=np.zeros(shape=(1, 2)),
+        )
+        maskHelper = MaskHelper()
+
+        photometries = []
+        photoVars = []
+
+        for i in range(1000):
+            flux = expectedFlux + stddev * self.np_random.normal(size=nSamples)
+
+            spectrum = PfsSingle(
+                target=target,
+                observations=observations,
+                wavelength=wavelength,
+                flux=flux,
+                mask=np.zeros(shape=nSamples, dtype=int),
+                sky=np.zeros(shape=nSamples, dtype=int),
+                covar=covar,
+                covar2=np.zeros(shape=(1, 1), dtype=int),
+                flags=maskHelper,
+            )
+
+            photo, error = filterCurve.photometer(spectrum, doComputeError=True)
+            photometries.append(photo)
+            photoVars.append(error**2)
+
+        measuredPhotoVar = np.var(photometries, ddof=1)
+        estimatedPhotoVar = np.mean(photoVars)
+        self.assertAlmostEqual(measuredPhotoVar, estimatedPhotoVar, places=1)
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    runTests(globals())


### PR DESCRIPTION
The denominators of chi^2 for comparing an observed spectrum with
broadband fluxes were the errors of broadband fluxes, the error of
the observed spectrum ignored. The error of the observed spectrum
is now taken into account.

This PR also includes two unrelated changes: (1) Output best-fit models (if such setting is described in `debug.py`) (2) Prevent fitFluxCal.py from outputting objective values for every loop.