### PR TITLE
PIPE2D-1596: fitFluxCal: Accept flux standards from HSC and Gaia

### DIFF
--- a/python/pfs/drp/stella/fitFluxCal.py
+++ b/python/pfs/drp/stella/fitFluxCal.py
@@ -29,6 +29,7 @@ from pfs.datamodel.pfsFluxReference import PfsFluxReference
 from .datamodel import PfsArm, PfsFiberArray, PfsMerged, PfsSimpleSpectrum, PfsSingle
 from .datamodel.pfsTargetSpectra import PfsCalibratedSpectra
 from .fitFocalPlane import FitFocalPlaneConfig, FitFocalPlaneTask
+from .fitPfsFluxReference import removeBadFluxes
 from .fitReference import FilterCurve
 from .fluxCalibrate import fluxCalibrate, FluxCalibrateConnections
 from .focalPlaneFunction import ConstantFocalPlaneFunction, FluxCalib
@@ -1041,6 +1042,12 @@ class FitFluxCalConfig(PipelineTaskConfig, pipelineConnections=FluxCalibrateConn
         default="psf",
         optional=False,
     )
+    fabricatedBroadbandFluxErrSNR = Field(
+        dtype=float,
+        default=0,
+        doc="If positive, fabricate flux errors in pfsConfig if all of them are NaN"
+        " (for old engineering data). The fabricated flux errors are such that S/N is this much.",
+    )
     smoothFilterWidth = Field(
         dtype=float,
         default=1.0,
@@ -1105,6 +1112,7 @@ class FitFluxCalTask(PipelineTask):
         pfsCalibratedLsf : `LsfDict`
             Line-spread functions for calibrated spectra.
         """
+        removeBadFluxes(pfsConfig, self.config.broadbandFluxType, self.config.fabricatedBroadbandFluxErrSNR)
         fluxCal = self.calculateCalibrations(pfsConfig, pfsMerged, pfsMergedLsf, references)
         fluxCalibrate(pfsMerged, pfsConfig, fluxCal)
 


### PR DESCRIPTION
Previously, only PS1 was available as the source of flux standards.
It was because we interpolate in a complicated way those parts of
spectra that are missing due to absent arms. This interpolation
routine was valid only with PS1 fluxes. We now accept flux standards
from HSC and Gaia by extending the interpolation routine.

This PR includes several commits to make the above change possible.