### PR TITLE
Tickets/pipe2d-1615: Minor Gen3 simplifications/cleanups

### DIFF
--- a/pipelines/fiberNorms.yaml
+++ b/pipelines/fiberNorms.yaml
@@ -1,4 +1,6 @@
 description: PFS fiberNorms construction
+instrument: lsst.obs.pfs.PrimeFocusSpectrograph
+
 tasks:
   isr:
     class: lsst.obs.pfs.isrTask.PfsIsrTask

--- a/pipelines/reduceExposure.yaml
+++ b/pipelines/reduceExposure.yaml
@@ -1,4 +1,6 @@
 description: Reduce an exposure
+instrument: lsst.obs.pfs.PrimeFocusSpectrograph
+
 tasks:
   isr:
     class: lsst.obs.pfs.isrTask.PfsIsrTask

--- a/python/pfs/drp/stella/calculateReferenceFlux.py
+++ b/python/pfs/drp/stella/calculateReferenceFlux.py
@@ -19,27 +19,27 @@ from .fitReference import FitReferenceTask
 from .selectFibers import SelectFibersTask
 
 
-class CalculateReferenceFluxConnections(PipelineTaskConnections, dimensions=("instrument", "exposure")):
+class CalculateReferenceFluxConnections(PipelineTaskConnections, dimensions=("instrument", "visit")):
     """Connections for CalculateReferenceFluxTask"""
 
     pfsMerged = InputConnection(
         name="pfsMerged",
         doc="Merged spectra from exposure",
         storageClass="PfsMerged",
-        dimensions=("instrument", "exposure"),
+        dimensions=("instrument", "visit"),
     )
     pfsConfig = PrerequisiteConnection(
         name="pfsConfig",
         doc="Top-end fiber configuration",
         storageClass="PfsConfig",
-        dimensions=("instrument", "exposure"),
+        dimensions=("instrument", "visit"),
     )
 
     references = OutputConnection(
         name="pfsFluxReference",
         doc="Fit reference spectrum of flux standards",
         storageClass="PfsFluxReference",
-        dimensions=("instrument", "exposure"),
+        dimensions=("instrument", "visit"),
     )
 
 
@@ -121,7 +121,7 @@ class CalculateReferenceFluxTask(CmdLineTask, PipelineTask):
             assert np.all(ss.wavelength == wavelength)
 
         references = PfsFluxReference(
-            Identity(visit=dataId["exposure"], pfsDesignId=dataId["pfs_design_id"]),
+            Identity(visit=dataId["visit"], pfsDesignId=dataId["pfs_design_id"]),
             results.pfsConfig.fiberId,
             wavelength,
             np.array([spectra[target].flux for target in results.pfsConfig]),


### PR DESCRIPTION
I think that calculateReferenceFlux.py is dead, but until it's removed it's less confusing to fix it