### PR TITLE
PIPE2D-1728: Drop SCIENCE_MASKED targets from pfsArm

### DIFF
--- a/python/pfs/drp/stella/reduceExposure.py
+++ b/python/pfs/drp/stella/reduceExposure.py
@@ -350,6 +350,9 @@ class ReduceExposureTask(PipelineTask):
         )
         pfsArm = spectra.toPfsArm(identity)
 
+        pfsArm = pfsArm.select(pfsConfig, targetType=~TargetType.SCIENCE_MASKED)
+        lsf = LsfDict({ff: lsf[ff] for ff in pfsArm.fiberId})
+
         if self.config.doApplyScreenResponse:
             self.screen.run(exposure.getMetadata(), pfsArm, pfsConfig)
         if self.config.doBarycentricCorrection and not getLamps(exposure.getMetadata()):


### PR DESCRIPTION
The observatory requests that SCIENCE_MASKED targets be removed from an pfsArm. Because such fibers are required in extraction, the removal must happen after extraction.