### PR TITLE
PIPE2D-1594: fitFluxCal.py: Fabricate narrow-J-band flux

### DIFF
--- a/python/pfs/drp/stella/fitFluxCal.py
+++ b/python/pfs/drp/stella/fitFluxCal.py
@@ -1405,9 +1405,7 @@ class FitFluxCalConfig(PipelineTaskConfig, pipelineConnections=FitFluxCalConnect
         default=0.01,
         optional=False,
     )
-    ignoredBroadbandFilters = ListField(
-        dtype=str, default=[], doc="Broadband filters not to use"
-    )
+    ignoredBroadbandFilters = ListField(dtype=str, default=[], doc="Broadband filters not to use")
     fabricatedBroadbandFluxErrSNR = Field(
         dtype=float,
         default=0,

--- a/python/pfs/drp/stella/fitFluxReference.py
+++ b/python/pfs/drp/stella/fitFluxReference.py
@@ -2308,6 +2308,7 @@ class FilterCurve(TransmissionCurve):
         "r_sdss": "SDSS/r_all_tel_atm13.dat",
         "i_sdss": "SDSS/i_all_tel_atm13.dat",
         "z_sdss": "SDSS/z_all_tel_atm13.dat",
+        "nj_fake": "fake/fake_narrow_J.dat",
     }
     """Mapping of filter name to filename"""
 


### PR DESCRIPTION
J-band flux included in the broad-band flux set would be useful
because it would limit the IR-end of the flux calibration vector.
We fabricate a narrow-J-band flux, guessing it from fluxes of
the other bands.