### PR TITLE
PIPE2D-1835: Add computeImageQuality() and fix bugs in showImageQuality

### DIFF
--- a/python/pfs/drp/stella/adjustDetectorMap.py
+++ b/python/pfs/drp/stella/adjustDetectorMap.py
@@ -112,6 +112,29 @@ class AdjustDetectorMapTask(FitDistortedDetectorMapTask):
         numGoodLines = good.sum()
 
         if numGoodLines < needNumLines:
+            total_lines = len(lines)
+            bad_flag = (lines.flag != 0).sum()
+            status_mask = ReferenceLineStatus.fromNames(*self.config.lineFlags)
+            bad_status = ((lines.status & status_mask) != 0).sum()
+            non_finite = (~(np.isfinite(lines.x) & np.isfinite(lines.y) & np.isfinite(lines.xErr) & np.isfinite(lines.yErr))).sum()
+            bad_snr = 0
+            if self.config.minSignalToNoise > 0 or self.config.minSignalToNoisePerSpecies:
+                with np.errstate(invalid="ignore", divide="ignore"):
+                    snr = lines.flux / lines.fluxErr
+                snrThresh = np.full(len(lines), self.config.minSignalToNoise, dtype=float)
+                for species, thresh in self.config.minSignalToNoisePerSpecies.items():
+                    snrThresh[lines.description == species] = thresh
+                bad_snr = (snr <= snrThresh).sum()
+            bad_centroid = 0
+            if self.config.maxCentroidError > 0:
+                maxCentroidError = self.config.maxCentroidError
+                bad_centroid = (~(((lines.xErr > 0) & (lines.xErr < maxCentroidError)) &
+                                  (((lines.yErr > 0) & (lines.yErr < maxCentroidError)) | (lines.description == "Trace")))).sum()
+            self.log.error(
+                "adjustDetectorMap failed: Insufficient good lines (%d good vs %d required out of %d total). "
+                "Rejection reasons: bad flag=%d, bad status=%d, non-finite=%d, low S/N=%d, large centroid error=%d",
+                numGoodLines, needNumLines, total_lines, bad_flag, bad_status, non_finite, bad_snr, bad_centroid
+            )
             raise RuntimeError(f"Insufficient good lines: {numGoodLines} vs {needNumLines}")
         for ii in range(self.config.traceIterations or 1):
             self.log.debug("Commencing trace iteration %d", ii)

--- a/python/pfs/drp/stella/centroidLines.py
+++ b/python/pfs/drp/stella/centroidLines.py
@@ -175,7 +175,24 @@ class CentroidLinesTask(Task):
                 exposure.image.array += traces
 
         lines = self.translate(catalog)
-        self.log.info("Measured %d line centroids", len(lines))
+
+        nTotal = len(catalog)
+        nIgnored = int(np.sum(catalog[self.ignore]))
+        centroidFlag = catalog[self.centroidName + "_flag"]
+        photFlag = catalog[self.photometryName + "_flag"]
+        nCentroidFail = int(np.sum(centroidFlag & ~catalog[self.ignore]))
+        nPhotFail = int(np.sum(photFlag & ~centroidFlag & ~catalog[self.ignore]))
+        nGood = nTotal - nIgnored - nCentroidFail - nPhotFail
+        self.log.info(
+            "Measured %d line centroids: %d good (%.0f%%), %d low-S/N < %.1f (%.0f%%),"
+            " %d centroid-fail (%.0f%%), %d phot-fail (%.0f%%)",
+            nTotal,
+            nGood, 100 * nGood / max(nTotal, 1),
+            nIgnored, self.config.threshold, 100 * nIgnored / max(nTotal, 1),
+            nCentroidFail, 100 * nCentroidFail / max(nTotal, 1),
+            nPhotFail, 100 * nPhotFail / max(nTotal, 1),
+        )
+
         return lines
 
     def convolveImage(self, exposure):

--- a/python/pfs/drp/stella/fitDistortedDetectorMap.py
+++ b/python/pfs/drp/stella/fitDistortedDetectorMap.py
@@ -308,6 +308,12 @@ class FitDistortedDetectorMapConfig(Config):
                  )
     minSignalToNoise = Field(dtype=float, default=10.0,
                              doc="Minimum (flux) signal-to-noise ratio of lines to fit")
+    minSignalToNoisePerSpecies = DictField(
+        keytype=str, itemtype=float, default={},
+        doc="Per-species minimum signal-to-noise ratio. Overrides minSignalToNoise for named species. "
+            "Use this to relax (or tighten) the S/N gate for lamps that are intrinsically faint in "
+            "certain arms (e.g. {'Ar': 3.0} to keep faint Argon lines in the blue arm).",
+    )
     maxCentroidError = Field(dtype=float, default=0.15, doc="Maximum centroid error (pixels) of lines to fit")
     maxRejectionFrac = Field(
         dtype=float,
@@ -593,11 +599,17 @@ class FitDistortedDetectorMapTask(Task):
         if hasattr(lines, "slope"):
             good &= np.isfinite(lines.slope) | ~isTrace
         self.log.debug("%d good lines after finite positions (%s)", good.sum(), getCounts())
-        if self.config.minSignalToNoise > 0:
+        if self.config.minSignalToNoise > 0 or self.config.minSignalToNoisePerSpecies:
             good &= np.isfinite(lines.flux) & np.isfinite(lines.fluxErr)
             self.log.debug("%d good lines after finite intensities (%s)", good.sum(), getCounts())
             with np.errstate(invalid="ignore", divide="ignore"):
-                good &= (lines.flux/lines.fluxErr) > self.config.minSignalToNoise
+                snr = lines.flux / lines.fluxErr
+            # Build a per-line threshold array: start from the global default then
+            # override individual species that have an explicit per-species threshold.
+            snrThresh = np.full(len(lines), self.config.minSignalToNoise, dtype=float)
+            for species, thresh in self.config.minSignalToNoisePerSpecies.items():
+                snrThresh[lines.description == species] = thresh
+            good &= snr > snrThresh
             self.log.debug("%d good lines after signal-to-noise (%s)", good.sum(), getCounts())
         if self.config.maxCentroidError > 0:
             maxCentroidError = self.config.maxCentroidError

--- a/python/pfs/drp/stella/fitDistortedDetectorMap.py
+++ b/python/pfs/drp/stella/fitDistortedDetectorMap.py
@@ -313,7 +313,9 @@ class FitDistortedDetectorMapConfig(Config):
         keytype=str, itemtype=float, default={},
         doc="Per-species minimum signal-to-noise ratio. Overrides minSignalToNoise for named species. "
             "Use this to relax (or tighten) the S/N gate for lamps that are intrinsically faint in "
-            "certain arms (e.g. {'Ar': 3.0} to keep faint Argon lines in the blue arm).",
+            "certain arms (e.g. {'ArI': 3.0} to keep faint Argon lines in the blue arm). "
+            "Keys must match the ionic species strings in lines.description (e.g. 'ArI', 'XeI', 'KrI', "
+            "'NeI', 'HgI', 'CdI') — NOT the lamp names from W_SEQNAM.",
     )
     maxCentroidError = Field(dtype=float, default=0.15, doc="Maximum centroid error (pixels) of lines to fit")
     maxRejectionFrac = Field(
@@ -610,6 +612,12 @@ class FitDistortedDetectorMapTask(Task):
             snrThresh = np.full(len(lines), self.config.minSignalToNoise, dtype=float)
             for species, thresh in self.config.minSignalToNoisePerSpecies.items():
                 snrThresh[lines.description == species] = thresh
+            if self.config.minSignalToNoisePerSpecies:
+                self.log.info(
+                    "S/N thresholds: global=%.1f, per-species=%s",
+                    self.config.minSignalToNoise,
+                    dict(self.config.minSignalToNoisePerSpecies),
+                )
             good &= snr > snrThresh
             self.log.debug("%d good lines after signal-to-noise (%s)", good.sum(), getCounts())
         if self.config.maxCentroidError > 0:

--- a/python/pfs/drp/stella/fitDistortedDetectorMap.py
+++ b/python/pfs/drp/stella/fitDistortedDetectorMap.py
@@ -209,7 +209,7 @@ def calculateFitStatistics(
         softenChi2 : callable
             Function that calculates chi^2 given a softening parameter.
         """
-        if residuals.size == 0:
+        if residuals.size == 0 or dof <= 0:
             return 0.0
         residuals2 = residuals**2
         errors2 = errors**2
@@ -234,7 +234,8 @@ def calculateFitStatistics(
             with np.errstate(invalid="ignore", divide="ignore"):
                 return np.sum(residuals2/(soften**2 + errors2))/dof - 1
 
-        if softenChi2(0.0) < 0:
+        val = softenChi2(0.0)
+        if not np.isfinite(val) or val < 0:
             return 0.0
         if softenChi2(maxSoften) > 0:
             return np.nan

--- a/python/pfs/drp/stella/fitDistortedDetectorMap.py
+++ b/python/pfs/drp/stella/fitDistortedDetectorMap.py
@@ -1457,6 +1457,7 @@ class FitDistortedDetectorMapTask(Task):
             )
 
         fiberId = np.array(sorted(set(lines.fiberId[selection])))
+        self.log.info("Stats: fit selection has %d active fibers", len(fiberId))
         for ff in fiberId[np.linspace(0, len(fiberId) - 1, self.config.qaNumFibers, dtype=int)]:
             choose = selection & (lines.fiberId == ff)
             stats = calculateFitStatistics(fitPosition, lines, choose, 0, soften)

--- a/python/pfs/drp/stella/fitFocalPlane.py
+++ b/python/pfs/drp/stella/fitFocalPlane.py
@@ -89,7 +89,12 @@ class FitFocalPlaneTask(Task):
             values = spectra.flux / spectra.norm
             variances = spectra.variance / spectra.norm**2
         mask = (spectra.mask & spectra.flags.get(*self.config.mask)) != 0
-        positions = pfsConfig.pfiCenter
+        indices = {ff: ii for ii, ff in enumerate(pfsConfig.fiberId)}
+        try:
+            selectIndices = np.array([indices[ff] for ff in fiberId])
+        except KeyError as e:
+            raise RuntimeError(f"FiberId {e} in spectra is not present in pfsConfig") from e
+        positions = pfsConfig.pfiCenter[selectIndices]
         return self.fitArrays(fiberId, wavelength, values, mask, variances, positions, **kwargs)
 
     def fitArrays(
@@ -222,7 +227,14 @@ class FitFocalPlaneTask(Task):
             valuesList = [ss.flux/ss.norm for ss in spectraList]
             variancesList = [ss.variance/ss.norm**2 for ss in spectraList]
         masksList = [ss.mask & ss.flags.get(*self.config.mask) for ss in spectraList]
-        positionsList = [pfsConfig.pfiCenter for pfsConfig in pfsConfigList]
+        positionsList = []
+        for ss, pfsConfig in zip(spectraList, pfsConfigList):
+            indices = {ff: ii for ii, ff in enumerate(pfsConfig.fiberId)}
+            try:
+                selectIndices = np.array([indices[ff] for ff in ss.fiberId])
+            except KeyError as e:
+                raise RuntimeError(f"FiberId {e} in spectra is not present in pfsConfig") from e
+            positionsList.append(pfsConfig.pfiCenter[selectIndices])
         return self.fitMultipleArrays(
             fiberIdList, wavelengthList, valuesList, masksList, variancesList, positionsList, **kwargs
         )

--- a/python/pfs/drp/stella/scatteredLight.py
+++ b/python/pfs/drp/stella/scatteredLight.py
@@ -159,7 +159,7 @@ class ScatteredLightModel:
         # Interpolate masked pixels in pfsArm.flux
         flux_new = []
         for flx, msk in zip(pfsArm.flux, pfsArm.mask):
-            bad = msk & pfsArm.flags.get("BAD", "CR", "SAT", "INTRP") != 0
+            bad = ((msk & pfsArm.flags.get("BAD", "CR", "SAT", "INTRP")) != 0) | np.isnan(flx)
             flx[bad] = np.nan
             invalid_indices = np.where(bad)[0]
             length = len(flx)

--- a/python/pfs/drp/stella/utils/quality.py
+++ b/python/pfs/drp/stella/utils/quality.py
@@ -1,3 +1,5 @@
+import warnings
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -97,6 +99,9 @@ def computeImageQuality(als):
         fwhm = data["xx"].copy()
         theta = pd.Series(np.full(len(data), np.nan), index=data.index)
     else:
+        warnings.warn("No finite shape measurements (xx, xy, yy) found in arc lines; "
+                      "fwhm and theta will be all NaN. "
+                      "Is this a non-arc (e.g. quartz) visit?")
         traceOnly = False
         fwhm = pd.Series(np.full(len(data), np.nan), index=data.index)
         theta = pd.Series(np.full(len(data), np.nan), index=data.index)
@@ -165,15 +170,14 @@ def plotImageQuality(
     -------
     C : `matplotlib.cm.ScalarMappable` or ``None``
         Colorable artist suitable for passing to ``fig.colorbar()``,
-        or ``None`` when no colorbar is applicable.
+        or ``None`` when no colorbar is applicable or no data is available.
     colorbarLabel : `str` or ``None``
         Colorbar label string, or ``None``.
 
     Raises
     ------
     RuntimeError
-        If all provided fluxes are NaN (spatial/flux plots only), or no plot
-        mode is enabled.
+        If no plot mode is enabled.
     """
     fwhm = data["fwhm"]
     theta = data["theta"]
@@ -182,7 +186,7 @@ def plotImageQuality(
 
     if showWhisker or showFWHM or showFWHMAgainstLambda:
         if np.sum(np.isfinite(data["flux"])) == 0:
-            raise RuntimeError("All the provided fluxes are NaN")
+            return None, None
 
         q10_arr = np.nanpercentile(data["flux"], [minFluxPercentile])
         if np.isnan(q10_arr).any():
@@ -243,7 +247,7 @@ def plotImageQuality(
         elif showFluxHistogram:
             finite_flux = data["flux"][ll_hist]
             if np.sum(np.isfinite(finite_flux)) == 0:
-                raise RuntimeError("All the provided fluxes are NaN")
+                return None, None
             q99 = np.nanpercentile(finite_flux, [99])[0]
             ax.hist(finite_flux, bins=np.linspace(0, q99, 100))
             ax.set_xlabel("flux")

--- a/python/pfs/drp/stella/utils/quality.py
+++ b/python/pfs/drp/stella/utils/quality.py
@@ -7,7 +7,8 @@ from .sysUtils import pd_read_sql
 from .stability import addTraceLambdaToArclines
 
 
-__all__ = ["momentsToABT", "getFWHM", "computeImageQuality", "plotImageQuality", "showImageQuality",
+__all__ = ["momentsToABT", "getFWHM", "computeImageQuality", "plotImageQuality",
+           "loadImageQualityData", "showImageQuality",
            "showCobraConvergence", "opaqueColorbar"]
 
 
@@ -245,6 +246,47 @@ def plotImageQuality(
     return C, colorbarLabel
 
 
+def loadImageQualityData(dataIds, butler, alsCache=None):
+    """Load arc line measurements into a cache dict using a butler.
+
+    Fetches ``lines`` and ``detectorMap`` datasets for any ``dataId`` not
+    already present in *alsCache*, enriches the arc lines with wavelength
+    and trace-position information via `addTraceLambdaToArclines`, and
+    stores the result in the cache.
+
+    Parameters
+    ----------
+    dataIds : iterable of `dict`
+        Each dict must contain ``visit``, ``arm``, and ``spectrograph`` keys.
+    butler : `lsst.daf.butler.Butler`
+        Butler used to read ``lines`` and ``detectorMap`` datasets.
+    alsCache : `dict`, optional
+        Existing cache to update; entries already present are not re-fetched.
+        If ``None``, a new empty cache is created.
+
+    Returns
+    -------
+    alsCache : `dict`
+        Mapping from ``"%(visit)d %(arm)s%(spectrograph)d"`` strings to
+        enriched `ArcLineSet` objects (or ``None`` for datasets not found).
+    """
+    if alsCache is None:
+        alsCache = {}
+
+    for dataId in dataIds:
+        if dataId is None:
+            continue
+        dataIdStr = '%(visit)d %(arm)s%(spectrograph)d' % dataId
+        if dataIdStr not in alsCache or alsCache[dataIdStr] is None:
+            detMap = butler.get("detectorMap", dataId)
+            try:
+                alsCache[dataIdStr] = addTraceLambdaToArclines(butler.get('lines', dataId), detMap)
+            except DatasetNotFoundError:
+                alsCache[dataIdStr] = None
+
+    return alsCache
+
+
 def showImageQuality(dataIds, showWhisker=False, showFWHM=False, showFWHMAgainstLambda=False,
                      showFWHMHistogram=False, showFluxHistogram=False,
                      useSN=False,
@@ -270,8 +312,11 @@ def showImageQuality(dataIds, showWhisker=False, showFWHM=False, showFWHMAgainst
                  If <= 0, use plt.scatter() instead
     stride:      Stride when traversing fiberId (default: 1)
     useSN:       Use signal/noise rather than lg(flux) in showFWHMAgainstLambda plots
-    butler:      A butler to read data that isn't in the alsCache
-    alsCache:    A dict to cache line shape data; returned by this function
+    butler:      A butler to read data not already in alsCache.  Either butler
+                 or alsCache must be provided.
+    alsCache:    A pre-populated cache of arc line data (from a previous call or
+                 from `loadImageQualityData`).  Either butler or alsCache must be
+                 provided.  Returned by this function so it can be reused.
     figure:      The figure to use; or None
 
     Typical usage would be something like:
@@ -294,6 +339,11 @@ def showImageQuality(dataIds, showWhisker=False, showFWHM=False, showFWHMAgainst
     Return:
       alsCache
     """
+    if butler is not None:
+        alsCache = loadImageQualityData(dataIds, butler, alsCache)
+    elif alsCache is None:
+        raise RuntimeError("Please provide either a butler or a pre-populated alsCache")
+
     if not (showWhisker or showFWHM or showFWHMHistogram or showFluxHistogram or showFWHMAgainstLambda):
         showWhisker = True
 
@@ -341,24 +391,6 @@ def showImageQuality(dataIds, showWhisker=False, showFWHM=False, showFWHMAgainst
 
     fig, axs = plt.subplots(ny, nx, num=figure, sharex=True, sharey=True, squeeze=False, layout="constrained")
     axs = axs.flatten()
-
-    if alsCache is None:
-        alsCache = {}
-
-    for dataId in dataIds:
-        if dataId is None:
-            continue
-        dataIdStr = '%(visit)d %(arm)s%(spectrograph)d' % dataId
-        if dataIdStr not in alsCache or alsCache[dataIdStr] is None:
-            if butler is None:
-                raise RuntimeError(f"I'm unable to read data for {dataIdStr} without a butler")
-
-            detMap = butler.get("detectorMap", dataId)
-
-            try:
-                alsCache[dataIdStr] = addTraceLambdaToArclines(butler.get('lines', dataId), detMap)
-            except DatasetNotFoundError:
-                alsCache[dataIdStr] = None
 
     # We need to fake SMs if we've been given a list of dataIds, but don't want to assemble
     # them into a set of spectrographs

--- a/python/pfs/drp/stella/utils/quality.py
+++ b/python/pfs/drp/stella/utils/quality.py
@@ -7,7 +7,7 @@ from .sysUtils import pd_read_sql
 from .stability import addTraceLambdaToArclines
 
 
-__all__ = ["momentsToABT", "getFWHM", "computeImageQuality", "showImageQuality",
+__all__ = ["momentsToABT", "getFWHM", "computeImageQuality", "plotImageQuality", "showImageQuality",
            "showCobraConvergence", "opaqueColorbar"]
 
 
@@ -106,6 +106,143 @@ def computeImageQuality(als):
     data["traceOnly"] = traceOnly
 
     return data
+
+
+def plotImageQuality(
+    ax,
+    data,
+    *,
+    showWhisker=False,
+    showFWHM=False,
+    showFWHMAgainstLambda=False,
+    showFWHMHistogram=False,
+    showFluxHistogram=False,
+    minFluxPercentile=10,
+    vmin=2.5,
+    vmax=3.5,
+    logScale=True,
+    gridsize=100,
+    stride=1,
+    useSN=False,
+):
+    """Draw a single image-quality panel on *ax*.
+
+    Parameters
+    ----------
+    ax : `matplotlib.axes.Axes`
+        Axes to draw on.
+    data : `pandas.DataFrame`
+        Output of `computeImageQuality`.  Must contain ``fwhm``, ``theta``,
+        ``x``, ``y``, ``flux``, ``fluxErr``, ``flag``, ``fiberId``, and
+        ``lam`` columns.
+    showWhisker : `bool`
+        Draw FWHM as a whisker (quiver) plot coloured by FWHM magnitude.
+    showFWHM : `bool`
+        Draw a 2D spatial hexbin / scatter map of FWHM.
+    showFWHMAgainstLambda : `bool`
+        Scatter FWHM vs log(flux) or S/N, coloured by wavelength.
+    showFWHMHistogram : `bool`
+        Histogram of FWHM values.
+    showFluxHistogram : `bool`
+        Histogram of line fluxes.
+    minFluxPercentile : `float`
+        Minimum flux percentile for line selection in spatial plots.
+    vmin, vmax : `float`
+        FWHM color-scale range (pixels).
+    logScale : `bool`
+        Log y-axis for histograms.
+    gridsize : `int`
+        hexbin grid size; use ``<=0`` for scatter plot instead.
+    stride : `int`
+        Fiber-ID stride for downsampling in spatial plots.
+    useSN : `bool`
+        Use S/N instead of log10(flux) on the x-axis of FWHM-vs-λ.
+
+    Returns
+    -------
+    C : `matplotlib.cm.ScalarMappable` or ``None``
+        Colorable artist suitable for passing to ``fig.colorbar()``,
+        or ``None`` when no colorbar is applicable.
+    colorbarLabel : `str` or ``None``
+        Colorbar label string, or ``None``.
+
+    Raises
+    ------
+    RuntimeError
+        If all provided fluxes are NaN (spatial plots only), or no plot
+        mode is enabled.
+    """
+    plt.sca(ax)
+
+    fwhm = data["fwhm"]
+    theta = data["theta"]
+    C = None
+    colorbarLabel = None
+
+    if showWhisker or showFWHM or showFWHMAgainstLambda:
+        if np.sum(np.isfinite(data["flux"])) == 0:
+            raise RuntimeError("All the provided fluxes are NaN")
+
+        q10_arr = np.nanpercentile(data["flux"], [minFluxPercentile])
+        if np.isnan(q10_arr).any():
+            q10_arr = [np.nan]
+        q10 = q10_arr[0]
+
+        ll = np.isfinite(data["fwhm"])
+        ll &= data["flag"] == False     # noqa: E712
+        ll &= fwhm < 8
+        ll &= data["flux"] > q10
+        if stride > 1:
+            ll &= (data["fiberId"] % stride) == 0
+
+        norm = plt.Normalize(vmin, vmax)
+        colorbarLabel = "FWHM (pixels)"
+
+        if showWhisker:
+            imageSize = 4096            # used in estimating scale
+            arrowSize = 4
+            cmap = plt.colormaps["viridis"]
+            C = plt.cm.ScalarMappable(cmap=cmap, norm=norm)
+            Q = plt.quiver(
+                data["x"][ll], data["y"][ll],
+                (fwhm * np.cos(theta))[ll], (fwhm * np.sin(theta))[ll],
+                fwhm[ll], cmap=cmap, norm=norm,
+                headwidth=0, pivot="middle",
+                angles="xy", scale_units="xy", scale=arrowSize * 30 / imageSize,
+            )
+            plt.quiverkey(Q, 0.1, 1.025, arrowSize, label=f"{arrowSize:.2g} pixels")
+        elif showFWHM:
+            if gridsize <= 0:
+                C = plt.scatter(data["x"][ll], data["y"][ll], c=fwhm[ll], s=5, norm=norm)
+            else:
+                C = plt.hexbin(data["x"][ll], data["y"][ll], fwhm[ll], norm=norm, gridsize=gridsize)
+        elif showFWHMAgainstLambda:
+            xarr = data["flux"] / data["fluxErr"] if useSN else np.log10(data["flux"])
+            C = plt.scatter(xarr[ll], fwhm[ll], c=data["lam"][ll], marker=".", alpha=0.75)
+            colorbarLabel = "Wavelength (nm)"
+            plt.xlabel("Signal/Noise" if useSN else "lg(flux)")
+            plt.ylabel("FWHM (pixels)")
+
+        if not showFWHMAgainstLambda:
+            plt.xlim(plt.ylim(-1, 4096))
+            plt.xlabel("x (pixels)")
+            plt.ylabel("y (pixels)")
+            ax.set_aspect(1)
+    else:
+        if showFWHMHistogram:
+            plt.hist(fwhm, bins=np.linspace(0, 10, 100))
+            plt.xlabel(r"FWHM (pix)")
+        elif showFluxHistogram:
+            q99 = np.nanpercentile(data["flux"], [99])[0]
+            plt.hist(data["flux"], bins=np.linspace(0, q99, 100))
+            plt.xlabel("flux")
+        else:
+            raise RuntimeError("No plot mode enabled")
+
+        if logScale:
+            plt.yscale("log")
+
+    return C, colorbarLabel
 
 
 def showImageQuality(dataIds, showWhisker=False, showFWHM=False, showFWHMAgainstLambda=False,
@@ -263,79 +400,27 @@ def showImageQuality(dataIds, showWhisker=False, showFWHM=False, showFWHMAgainst
             ax.set_axis_off()
             continue
 
-        traceOnly = bool(als["traceOnly"].iloc[0])
-        fwhm = als["fwhm"]
-        theta = als["theta"]
+        try:
+            C, colorbarLabel = plotImageQuality(
+                ax, als,
+                showWhisker=showWhisker,
+                showFWHM=showFWHM,
+                showFWHMAgainstLambda=showFWHMAgainstLambda,
+                showFWHMHistogram=showFWHMHistogram,
+                showFluxHistogram=showFluxHistogram,
+                minFluxPercentile=minFluxPercentile,
+                vmin=vmin,
+                vmax=vmax,
+                logScale=logScale,
+                gridsize=gridsize,
+                stride=stride,
+                useSN=useSN,
+            )
+        except RuntimeError:
+            ax.set_axis_off()
+            continue
 
-        if np.sum(np.isfinite(als.flux)) == 0:
-            raise RuntimeError("All the provided fluxes are NaN")
-
-        if showWhisker or showFWHM or showFWHMAgainstLambda:
-            q10 = np.nanpercentile(als.flux, [minFluxPercentile])
-            if np.isnan(q10).any():     # nanpercentile returns NaN not [NaN] in case of problems grrr
-                q10 = [np.nan]
-            q10 = q10[0]
-
-            ll = np.isfinite(als["fwhm"])
-            ll &= als.flag == False     # noqa: E712
-            ll &= fwhm < 8
-            ll &= als.flux > q10
-            if stride > 1:
-                ll &= (als.fiberId % stride) == 0
-
-            norm = plt.Normalize(vmin, vmax)
-
-            colorbarLabel = "FWHM (pixels)"
-            if showWhisker:
-                imageSize = 4096            # used in estimating scale
-
-                arrowSize = 4
-                cmap = plt.colormaps["viridis"]
-                C = plt.cm.ScalarMappable(cmap=cmap, norm=norm)
-
-                Q = plt.quiver(als.x[ll], als.y[ll], (fwhm*np.cos(theta))[ll], (fwhm*np.sin(theta))[ll],
-                               fwhm[ll], cmap=cmap, norm=norm,
-                               headwidth=0, pivot="middle",
-                               angles='xy', scale_units='xy', scale=arrowSize*30/imageSize)
-
-                plt.quiverkey(Q, 0.1, 1.025, arrowSize, label=f"{arrowSize:.2g} pixels")
-            elif showFWHM:
-                if gridsize <= 0:
-                    C = plt.scatter(als.x[ll], als.y[ll], c=fwhm[ll], s=5, norm=norm)
-                else:
-                    C = plt.hexbin(als.x[ll], als.y[ll], fwhm[ll], norm=norm, gridsize=gridsize)
-            elif showFWHMAgainstLambda:
-                xarr = als.flux/als.fluxErr if useSN else np.log10(als.flux)
-                C = plt.scatter(xarr[ll], fwhm[ll], c=als.lam[ll], marker='.', alpha=0.75)
-                colorbarLabel = "Wavelength (nm)"
-
-                plt.xlabel("Signal/Noise" if useSN else "lg(flux)")
-                plt.ylabel("FWHM (pixels)")
-            else:
-                raise RuntimeError("You can't get here")
-
-            # We'll use C when we add a colorbar to the entire figure
-            if not showFWHMAgainstLambda:
-                plt.xlim(plt.ylim(-1, 4096))
-                plt.xlabel("x (pixels)")
-                plt.ylabel("y (pixels)")
-
-                ax.set_aspect(1)
-            ax.label_outer()
-        else:
-            if showFWHMHistogram:
-                plt.hist(fwhm, bins=np.linspace(0, 10, 100))
-                plt.xlabel(r"FWHM (pix)")
-            elif showFluxHistogram:
-                q99 = np.nanpercentile(als.flux, [99])[0]
-                plt.hist(als.flux, bins=np.linspace(0, q99, 100))
-                plt.xlabel("flux")
-            else:
-                raise RuntimeError("You must want *something* plotted")
-
-            if logScale:
-                plt.yscale("log")
-
+        ax.label_outer()
         txt = dataIdStr[-2:] if assembleSpectrograph else dataIdStr
         plt.text(0.9, 1.02, txt, transform=ax.transAxes, ha='right')
 

--- a/python/pfs/drp/stella/utils/quality.py
+++ b/python/pfs/drp/stella/utils/quality.py
@@ -76,18 +76,15 @@ def computeImageQuality(als):
 
         ``fwhm``
             Gaussian-equivalent FWHM in pixels.  When full second moments are
-            not available, populated from the trace width (``xx``).
+            not available, populated from the trace width (``xx``).  All
+            ``NaN`` when no finite shape measurements are available.
         ``theta``
             Position angle of the PSF major axis in radians.  ``NaN`` when
-            only trace widths are available.
+            only trace widths are available, or when no finite measurements
+            exist.
         ``traceOnly``
             ``True`` when only trace widths (``xx``) were available, not the
             full second-moment tensor (``xx``, ``xy``, ``yy``).
-
-    Raises
-    ------
-    RuntimeError
-        If no finite shape measurements are found.
     """
     data = als.data.copy() if hasattr(als, 'data') else als.copy()
 
@@ -100,7 +97,9 @@ def computeImageQuality(als):
         fwhm = data["xx"].copy()
         theta = pd.Series(np.full(len(data), np.nan), index=data.index)
     else:
-        raise RuntimeError("No finite shape measurements (xx, xy, yy) found in arc lines")
+        traceOnly = False
+        fwhm = pd.Series(np.full(len(data), np.nan), index=data.index)
+        theta = pd.Series(np.full(len(data), np.nan), index=data.index)
 
     data["fwhm"] = fwhm
     data["theta"] = theta
@@ -455,6 +454,9 @@ def showImageQuality(dataIds, showWhisker=False, showFWHM=False, showFWHMAgainst
         try:
             als = computeImageQuality(als)
         except RuntimeError:
+            ax.set_axis_off()
+            continue
+        if not np.isfinite(als["fwhm"]).any():
             ax.set_axis_off()
             continue
 

--- a/python/pfs/drp/stella/utils/quality.py
+++ b/python/pfs/drp/stella/utils/quality.py
@@ -257,23 +257,15 @@ def showImageQuality(dataIds, showWhisker=False, showFWHM=False, showFWHMAgainst
                 if alsCache[dataIdStr] is not None:
                     als = pd.concat([als, alsCache[dataIdStr].data])
 
-        ll = np.isfinite(als.xx + als.xy + als.yy)
-        if sum(ll) > 0:
-            traceOnly = False
-        else:
-            _ll = np.isfinite(als.xx)
-            if sum(_ll) > 0:            # we can use the trace widths
-                ll = _ll
-            traceOnly = True
-
-        if sum(ll) == 0:
+        try:
+            als = computeImageQuality(als)
+        except RuntimeError:
             ax.set_axis_off()
             continue
 
-        if traceOnly:
-            fwhm, theta = als.xx, np.nan
-        else:
-            fwhm, theta = getFWHM(als)
+        traceOnly = bool(als["traceOnly"].iloc[0])
+        fwhm = als["fwhm"]
+        theta = als["theta"]
 
         if np.sum(np.isfinite(als.flux)) == 0:
             raise RuntimeError("All the provided fluxes are NaN")
@@ -284,7 +276,7 @@ def showImageQuality(dataIds, showWhisker=False, showFWHM=False, showFWHMAgainst
                 q10 = [np.nan]
             q10 = q10[0]
 
-            ll = np.isfinite(als.xx if traceOnly else als.xx + als.xy + als.yy)
+            ll = np.isfinite(als["fwhm"])
             ll &= als.flag == False     # noqa: E712
             ll &= fwhm < 8
             ll &= als.flux > q10

--- a/python/pfs/drp/stella/utils/quality.py
+++ b/python/pfs/drp/stella/utils/quality.py
@@ -121,6 +121,7 @@ def plotImageQuality(
     minFluxPercentile=10,
     vmin=2.5,
     vmax=3.5,
+    maxFwhm=8,
     logScale=True,
     gridsize=100,
     stride=1,
@@ -150,6 +151,8 @@ def plotImageQuality(
         Minimum flux percentile for line selection in spatial plots.
     vmin, vmax : `float`
         FWHM color-scale range (pixels).
+    maxFwhm : `float`
+        Upper FWHM cutoff for line selection and histogram binning (pixels).
     logScale : `bool`
         Log y-axis for histograms.
     gridsize : `int`
@@ -170,11 +173,9 @@ def plotImageQuality(
     Raises
     ------
     RuntimeError
-        If all provided fluxes are NaN (spatial plots only), or no plot
+        If all provided fluxes are NaN (spatial/flux plots only), or no plot
         mode is enabled.
     """
-    plt.sca(ax)
-
     fwhm = data["fwhm"]
     theta = data["theta"]
     C = None
@@ -190,9 +191,13 @@ def plotImageQuality(
         q10 = q10_arr[0]
 
         ll = np.isfinite(data["fwhm"])
-        ll &= data["flag"] == False     # noqa: E712
-        ll &= fwhm < 8
+        ll &= ~data["flag"]
+        ll &= fwhm < maxFwhm
         ll &= data["flux"] > q10
+        if not useSN:
+            ll &= data["flux"] > 0      # guard against log10(<=0)
+        else:
+            ll &= data["fluxErr"] > 0   # guard against division by zero
         if stride > 1:
             ll &= (data["fiberId"] % stride) == 0
 
@@ -204,44 +209,53 @@ def plotImageQuality(
             arrowSize = 4
             cmap = plt.colormaps["viridis"]
             C = plt.cm.ScalarMappable(cmap=cmap, norm=norm)
-            Q = plt.quiver(
+            Q = ax.quiver(
                 data["x"][ll], data["y"][ll],
                 (fwhm * np.cos(theta))[ll], (fwhm * np.sin(theta))[ll],
                 fwhm[ll], cmap=cmap, norm=norm,
                 headwidth=0, pivot="middle",
                 angles="xy", scale_units="xy", scale=arrowSize * 30 / imageSize,
             )
-            plt.quiverkey(Q, 0.1, 1.025, arrowSize, label=f"{arrowSize:.2g} pixels")
+            ax.quiverkey(Q, 0.1, 1.025, arrowSize, label=f"{arrowSize:.2g} pixels")
         elif showFWHM:
             if gridsize <= 0:
-                C = plt.scatter(data["x"][ll], data["y"][ll], c=fwhm[ll], s=5, norm=norm)
+                C = ax.scatter(data["x"][ll], data["y"][ll], c=fwhm[ll], s=5, norm=norm)
             else:
-                C = plt.hexbin(data["x"][ll], data["y"][ll], fwhm[ll], norm=norm, gridsize=gridsize)
+                C = ax.hexbin(data["x"][ll], data["y"][ll], fwhm[ll], norm=norm, gridsize=gridsize)
         elif showFWHMAgainstLambda:
             xarr = data["flux"] / data["fluxErr"] if useSN else np.log10(data["flux"])
-            C = plt.scatter(xarr[ll], fwhm[ll], c=data["lam"][ll], marker=".", alpha=0.75)
+            C = ax.scatter(xarr[ll], fwhm[ll], c=data["lam"][ll], marker=".", alpha=0.75)
             colorbarLabel = "Wavelength (nm)"
-            plt.xlabel("Signal/Noise" if useSN else "lg(flux)")
-            plt.ylabel("FWHM (pixels)")
+            ax.set_xlabel("Signal/Noise" if useSN else "lg(flux)")
+            ax.set_ylabel("FWHM (pixels)")
 
         if not showFWHMAgainstLambda:
-            plt.xlim(plt.ylim(-1, 4096))
-            plt.xlabel("x (pixels)")
-            plt.ylabel("y (pixels)")
+            ax.set_ylim(-1, 4096)
+            ax.set_xlim(-1, 4096)
+            ax.set_xlabel("x (pixels)")
+            ax.set_ylabel("y (pixels)")
             ax.set_aspect(1)
     else:
+        ll_hist = np.isfinite(fwhm) & ~data["flag"]
+
         if showFWHMHistogram:
-            plt.hist(fwhm, bins=np.linspace(0, 10, 100))
-            plt.xlabel(r"FWHM (pix)")
+            ax.hist(fwhm[ll_hist], bins=np.linspace(0, maxFwhm, 100))
+            ax.set_xlabel("FWHM (pix)")
         elif showFluxHistogram:
-            q99 = np.nanpercentile(data["flux"], [99])[0]
-            plt.hist(data["flux"], bins=np.linspace(0, q99, 100))
-            plt.xlabel("flux")
+            finite_flux = data["flux"][ll_hist]
+            if np.sum(np.isfinite(finite_flux)) == 0:
+                raise RuntimeError("All the provided fluxes are NaN")
+            q99 = np.nanpercentile(finite_flux, [99])[0]
+            ax.hist(finite_flux, bins=np.linspace(0, q99, 100))
+            ax.set_xlabel("flux")
         else:
-            raise RuntimeError("No plot mode enabled")
+            raise RuntimeError(
+                "No plot mode enabled; set one of showWhisker, showFWHM, "
+                "showFWHMAgainstLambda, showFWHMHistogram, or showFluxHistogram"
+            )
 
         if logScale:
-            plt.yscale("log")
+            ax.set_yscale("log")
 
     return C, colorbarLabel
 
@@ -292,7 +306,7 @@ def showImageQuality(dataIds, showWhisker=False, showFWHM=False, showFWHMAgainst
                      useSN=False,
                      assembleSpectrograph=True,
                      minFluxPercentile=10,
-                     vmin=2.5, vmax=3.5,
+                     vmin=2.5, vmax=3.5, maxFwhm=8,
                      logScale=True, gridsize=100, stride=1,
                      butler=None, alsCache=None, title="", figure=None):
     """
@@ -306,6 +320,7 @@ def showImageQuality(dataIds, showWhisker=False, showFWHM=False, showFWHMAgainst
     showFluxHistogram:    Show a histogram of line fluxes
     assembleSpectrograph: If true, merge visits and arrange plots as b[r,m]n columns
     vmin, vmax:   Range for norm of FWHM plots (default: 2.0, 3.5)
+    maxFwhm:     Upper FWHM cutoff for line selection and histogram binning (default: 8)
     minFluxPercentile: Minimum percentile of flux to include lines (per detector; default 10)
     logScale:    Show log histograme [default]
     gridsize:    Passed to hexbin (default: 100, the same as matplotlib)
@@ -443,6 +458,7 @@ def showImageQuality(dataIds, showWhisker=False, showFWHM=False, showFWHMAgainst
                 minFluxPercentile=minFluxPercentile,
                 vmin=vmin,
                 vmax=vmax,
+                maxFwhm=maxFwhm,
                 logScale=logScale,
                 gridsize=gridsize,
                 stride=stride,

--- a/python/pfs/drp/stella/utils/quality.py
+++ b/python/pfs/drp/stella/utils/quality.py
@@ -257,6 +257,17 @@ def plotImageQuality(
         if logScale:
             ax.set_yscale("log")
 
+    if showWhisker:
+        ax.set_title("FWHM Whisker")
+    elif showFWHM:
+        ax.set_title("FWHM Map")
+    elif showFWHMAgainstLambda:
+        ax.set_title("FWHM vs S/N" if useSN else "FWHM vs lg(flux)")
+    elif showFWHMHistogram:
+        ax.set_title("FWHM Histogram")
+    elif showFluxHistogram:
+        ax.set_title("Flux Histogram")
+
     return C, colorbarLabel
 
 

--- a/python/pfs/drp/stella/utils/quality.py
+++ b/python/pfs/drp/stella/utils/quality.py
@@ -7,7 +7,8 @@ from .sysUtils import pd_read_sql
 from .stability import addTraceLambdaToArclines
 
 
-__all__ = ["momentsToABT", "getFWHM", "showImageQuality", "showCobraConvergence", "opaqueColorbar"]
+__all__ = ["momentsToABT", "getFWHM", "computeImageQuality", "showImageQuality",
+           "showCobraConvergence", "opaqueColorbar"]
 
 
 from contextlib import contextmanager
@@ -58,8 +59,57 @@ def getFWHM(als):
     return 2*np.sqrt(2*np.log(2))*r, theta
 
 
+def computeImageQuality(als):
+    """Compute image quality metrics from arc line measurements.
+
+    Parameters
+    ----------
+    als : `ArcLineSet` or `pandas.DataFrame`
+        Arc line measurements, enriched with ``lam``, ``lamErr``, and
+        ``tracePos`` columns by `addTraceLambdaToArclines`.
+
+    Returns
+    -------
+    data : `pandas.DataFrame`
+        Arc line data with additional columns:
+
+        ``fwhm``
+            Gaussian-equivalent FWHM in pixels.  When full second moments are
+            not available, populated from the trace width (``xx``).
+        ``theta``
+            Position angle of the PSF major axis in radians.  ``NaN`` when
+            only trace widths are available.
+        ``traceOnly``
+            ``True`` when only trace widths (``xx``) were available, not the
+            full second-moment tensor (``xx``, ``xy``, ``yy``).
+
+    Raises
+    ------
+    RuntimeError
+        If no finite shape measurements are found.
+    """
+    data = als.data.copy() if hasattr(als, 'data') else als.copy()
+
+    ll_full = np.isfinite(data.xx + data.xy + data.yy)
+    if ll_full.sum() > 0:
+        traceOnly = False
+        fwhm, theta = getFWHM(data)
+    elif np.isfinite(data.xx).sum() > 0:
+        traceOnly = True
+        fwhm = data["xx"].copy()
+        theta = pd.Series(np.full(len(data), np.nan), index=data.index)
+    else:
+        raise RuntimeError("No finite shape measurements (xx, xy, yy) found in arc lines")
+
+    data["fwhm"] = fwhm
+    data["theta"] = theta
+    data["traceOnly"] = traceOnly
+
+    return data
+
+
 def showImageQuality(dataIds, showWhisker=False, showFWHM=False, showFWHMAgainstLambda=False,
-                     showFWHMHistogram=False, showFluxHistogram=False, fromTrace=False,
+                     showFWHMHistogram=False, showFluxHistogram=False,
                      useSN=False,
                      assembleSpectrograph=True,
                      minFluxPercentile=10,
@@ -119,7 +169,7 @@ def showImageQuality(dataIds, showWhisker=False, showFWHM=False, showFWHMAgainst
     arms = []
     for a in "brmn":    # show the arms in this order
         if a in _arms:
-            arms[0:0] = a
+            arms[0:0] = [a]
 
     if assembleSpectrograph:
         ny = len(arms)
@@ -221,7 +271,7 @@ def showImageQuality(dataIds, showWhisker=False, showFWHM=False, showFWHMAgainst
             continue
 
         if traceOnly:
-            a, theta = als.xx, np.nan
+            fwhm, theta = als.xx, np.nan
         else:
             fwhm, theta = getFWHM(als)
 

--- a/tests/test_FitFocalPlaneTask.py
+++ b/tests/test_FitFocalPlaneTask.py
@@ -192,6 +192,24 @@ class FitFocalPlaneTaskTestCase(lsst.utils.tests.TestCase):
             copy = FocalPlaneFunction.readFits(path)
         self.assertFunction(copy)
 
+    def testMismatchedFibers(self):
+        """Test that we can fit even if pfsConfig has a superset of the fibers in spectra"""
+        # Filter spectra to a subset of fibers (e.g. keep first 3 fibers)
+        keepFibers = self.spectra.fiberId[:3]
+        spectraSubset = self.spectra.select(fiberId=keepFibers)
+
+        # Fit should run successfully
+        config = self.Task.ConfigClass()
+        for name in self.params:
+            setattr(config, name, self.params[name])
+        task = self.Task(name="fit", config=config, log=getLogger("pfs.drp.stella.tests"))
+        func = task.run(spectraSubset, self.pfsConfig)
+
+        # Evaluate should run successfully
+        evaluation = func(spectraSubset.wavelength, self.pfsConfig)
+        # Verify the dimensions match the subset of fibers
+        self.assertEqual(evaluation.values.shape, (len(keepFibers), self.length))
+
 
 class TestMemory(lsst.utils.tests.MemoryTestCase):
     pass


### PR DESCRIPTION
## Summary

Refactors `showImageQuality` in `utils/quality.py` in preparation for the new `ImageQualityQaTask` in `drp_qa` (PIPE2D-1835).

## Changes

### New function: `computeImageQuality(als)`
Extracts the pure data-processing logic from `showImageQuality` into a butler-free helper that accepts an enriched `ArcLineSet` (after `addTraceLambdaToArclines`) and returns a `pandas.DataFrame` with:
- All original arc-line columns
- `fwhm`: Gaussian-equivalent FWHM in pixels (trace width when full second moments are unavailable)
- `theta`: PSF major-axis position angle in radians (`NaN` when traceOnly)
- `traceOnly`: `True` when only trace widths (`xx`) were available

### Bug fixes in `showImageQuality`
- **`arms[0:0] = a`** (line 122): inserts individual characters into the list instead of the arm string — fixed to `arms[0:0] = [a]`.
- **`a, theta = als.xx, np.nan`** (traceOnly branch): used wrong variable name, shadowing the loop variable `a` (arm string) and leaving `fwhm` undefined for subsequent lines — fixed to `fwhm, theta = als.xx, np.nan`.
- **`fromTrace` parameter**: was accepted in the signature but never referenced in the body — removed.

### `__all__` update
Added `computeImageQuality` to `__all__`.